### PR TITLE
Automate release process via PR merge

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,8 @@
 name: Publish Plugin
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -14,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0 # Need full history to check for existing tags
 
       - name: Setup Java 17
         uses: actions/setup-java@v4
@@ -23,8 +24,90 @@ jobs:
           architecture: x64
           distribution: "temurin"
 
-      - name: Publish plugin
+      - name: Extract version from build.gradle
+        id: get_version
+        run: |
+          VERSION=$(grep "^version = " build.gradle | sed "s/version = '\(.*\)'/\1/")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+          echo "Detected version: $VERSION"
+
+      - name: Check if release already exists
+        id: check_release
+        run: |
+          if git rev-parse "v${{ steps.get_version.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Tag v${{ steps.get_version.outputs.version }} already exists, skipping release"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Tag v${{ steps.get_version.outputs.version }} does not exist, proceeding with release"
+          fi
+
+      - name: Publish plugin to registry
+        if: steps.check_release.outputs.exists == 'false'
         run: make release
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           NPR_API_KEY: ${{ secrets.NF_PLUGIN_PUBLISH_TOKEN }}
+
+      - name: Extract changelog for version
+        if: steps.check_release.outputs.exists == 'false'
+        id: changelog
+        run: |
+          VERSION="${{ steps.get_version.outputs.version }}"
+
+          # Extract changelog section for this version
+          if [ -f CHANGELOG.md ]; then
+            # Try to extract section between ## [version] and next ## heading
+            CHANGELOG=$(sed -n "/## \[${VERSION}\]/,/## \[/p" CHANGELOG.md | sed '$d' | tail -n +2)
+
+            # If that didn't work, try without brackets
+            if [ -z "$CHANGELOG" ]; then
+              CHANGELOG=$(sed -n "/## ${VERSION}/,/## /p" CHANGELOG.md | sed '$d' | tail -n +2)
+            fi
+
+            # If still empty, use a default message
+            if [ -z "$CHANGELOG" ]; then
+              CHANGELOG="Release version ${VERSION}"
+            fi
+          else
+            CHANGELOG="Release version ${VERSION}"
+          fi
+
+          # Save to file for gh release create
+          echo "$CHANGELOG" > /tmp/changelog.txt
+          echo "Changelog extracted for version $VERSION"
+
+      - name: Create git tag and GitHub release
+        if: steps.check_release.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ steps.get_version.outputs.tag }}"
+          VERSION="${{ steps.get_version.outputs.version }}"
+
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Create and push tag
+          git tag -a "$TAG" -m "Release $VERSION"
+          git push origin "$TAG"
+
+          # Create GitHub release
+          gh release create "$TAG" \
+            --title "Release $VERSION" \
+            --notes-file /tmp/changelog.txt
+
+      - name: Release complete
+        if: steps.check_release.outputs.exists == 'false'
+        run: |
+          echo "✅ Release ${{ steps.get_version.outputs.version }} completed successfully!"
+          echo "   - Plugin published to Nextflow registry"
+          echo "   - Git tag ${{ steps.get_version.outputs.tag }} created"
+          echo "   - GitHub release created"
+
+      - name: Release skipped
+        if: steps.check_release.outputs.exists == 'true'
+        run: |
+          echo "⏭️  Release ${{ steps.get_version.outputs.version }} already exists, skipping"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -193,32 +193,66 @@ To publish the plugin to the Nextflow Plugin Registry:
 
 ### Creating a Release
 
-1. **Update version number** in `build.gradle`
+Releases are fully automated via GitHub Actions when you merge a PR that updates the version:
+
+1. **Create a release PR**
+
+   ```bash
+   git checkout -b release/v0.2.0
+   ```
+
+2. **Update version number** in `build.gradle`
 
    ```groovy
    version = '0.2.0'
    ```
 
-2. **Update CHANGELOG** (if applicable) with new version details
+3. **Update CHANGELOG.md** with release notes
 
-3. **Create and push a tag**
+   ```markdown
+   ## [0.2.0] - 2024-01-15
 
-   ```bash
-   git tag v0.2.0
-   git push origin v0.2.0
+   ### Added
+
+   - New feature description
+
+   ### Fixed
+
+   - Bug fix description
    ```
 
-4. **Publish to registry**
+4. **Commit and push**
 
    ```bash
-   make release
+   git add build.gradle CHANGELOG.md
+   git commit -m "chore: release v0.2.0"
+   git push origin release/v0.2.0
    ```
 
-   Or manually:
+5. **Create and merge PR**
 
-   ```bash
-   ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
-   ```
+   Open a pull request to `main` branch. Once merged, the automation will:
+
+   - ✅ Publish plugin to Nextflow Plugin Registry
+   - ✅ Create git tag (e.g., `v0.2.0`)
+   - ✅ Create GitHub release with changelog
+
+**That's it!** No manual steps required after merging the PR.
+
+### Manual Release (if needed)
+
+If you need to manually trigger a release, use the GitHub Actions workflow:
+
+1. Go to Actions → Publish Plugin
+2. Click "Run workflow"
+3. Select the `main` branch
+4. Click "Run workflow"
+
+Or publish locally (requires `npr.apiKey` in `~/.gradle/gradle.properties`):
+
+```bash
+make release
+```
 
 > **Note**: The Nextflow Plugin Registry is currently available as preview technology. Contact info@nextflow.io to learn how to get access.
 


### PR DESCRIPTION
Simplifies the release workflow to a single action: merge a PR that updates
the version in build.gradle.

Changes:
- Modified .github/workflows/publish.yml to trigger on push to main
- Workflow now automatically creates git tags and GitHub releases
- Extracts version from build.gradle and creates v{version} tags
- Parses CHANGELOG.md to include release notes in GitHub release
- Idempotent: skips if tag already exists
- Updated docs/CONTRIBUTING.md with new release process

After this change, releasing requires only:
1. Create PR updating version in build.gradle and CHANGELOG.md
2. Merge PR to main
3. Automation handles: registry publish + git tag + GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

