### PR TITLE
Release/v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Automated Release Process**: Simplified release workflow to a single action (merge PR)
+  - Modified `.github/workflows/publish.yml` to trigger on push to main branch
+  - Workflow now automatically extracts version from `build.gradle`
+  - Automatically creates git tags in `v{version}` format
+  - Automatically creates GitHub releases with changelog notes
+  - Idempotent: safe to re-run, skips if tag already exists
+  - Updated `docs/CONTRIBUTING.md` with new release process documentation
+  - Release now requires only: (1) create PR with version bump, (2) merge to main
 - **Documentation Reorganization**: Simplified README from 455 to ~165 lines for better onboarding
   - Moved detailed content to dedicated documentation pages
   - Created `docs/USAGE.md` with comprehensive usage patterns and examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to the nf-slack plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2025-11-03
+
+### Changed
+
+- **Automated Release Process**: Simplified release workflow to a single action (merge PR)
+  - Modified `.github/workflows/publish.yml` to trigger on push to main branch
+  - Workflow now automatically extracts version from `build.gradle`
+  - Automatically creates git tags in `v{version}` format
+  - Automatically creates GitHub releases with changelog notes
+  - Idempotent: safe to re-run, skips if tag already exists
+  - Updated `docs/CONTRIBUTING.md` with new release process documentation
+  - Release now requires only: (1) create PR with version bump, (2) merge to main
+- **Documentation Reorganization**: Simplified README from 455 to ~165 lines for better onboarding
+  - Moved detailed content to dedicated documentation pages
+  - Created `docs/USAGE.md` with comprehensive usage patterns and examples
+  - Created `docs/TROUBLESHOOTING.md` with common issues and solutions
+  - Moved `example/configs/README.md` to `docs/EXAMPLES.md` for centralized documentation
+  - Enhanced `docs/CONFIG.md` with cross-references to other documentation
+  - README now focuses on quick start with clear paths to detailed documentation
+  - Added basic customization examples without overwhelming API details
+
 ## [0.1.0] - 2025-10-30
 
 ### Added
@@ -106,25 +127,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- **Automated Release Process**: Simplified release workflow to a single action (merge PR)
-  - Modified `.github/workflows/publish.yml` to trigger on push to main branch
-  - Workflow now automatically extracts version from `build.gradle`
-  - Automatically creates git tags in `v{version}` format
-  - Automatically creates GitHub releases with changelog notes
-  - Idempotent: safe to re-run, skips if tag already exists
-  - Updated `docs/CONTRIBUTING.md` with new release process documentation
-  - Release now requires only: (1) create PR with version bump, (2) merge to main
-- **Documentation Reorganization**: Simplified README from 455 to ~165 lines for better onboarding
-  - Moved detailed content to dedicated documentation pages
-  - Created `docs/USAGE.md` with comprehensive usage patterns and examples
-  - Created `docs/TROUBLESHOOTING.md` with common issues and solutions
-  - Moved `example/configs/README.md` to `docs/EXAMPLES.md` for centralized documentation
-  - Enhanced `docs/CONFIG.md` with cross-references to other documentation
-  - README now focuses on quick start with clear paths to detailed documentation
-  - Added basic customization examples without overwhelming API details
-
 ### Planned
 
 - Asynchronous message sending with ExecutorService
@@ -137,6 +139,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Version History
 
+- **[0.1.1]** - Release automation and documentation improvements
 - **[0.1.0]** - Initial release with automatic notifications, custom messages, and progressive configuration examples
 
-[0.1.0]: https://github.com/seqeralabs/nf-slack/releases/tag/v0.1.0
+[0.1.1]: https://github.com/adamrtalbot/nf-slack/releases/tag/v0.1.1
+[0.1.0]: https://github.com/adamrtalbot/nf-slack/releases/tag/v0.1.0

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'io.nextflow.nextflow-plugin' version '1.0.0-beta.10'
 }
 
-version = '0.1.0'
+version = '0.1.1'
 
 nextflowPlugin {
     nextflowVersion = '24.10.0'


### PR DESCRIPTION
## Why

This is the first release using the new automated release workflow (merged in #6). It demonstrates the simplified release process and includes documentation improvements made since v0.1.0.

## What

**Version bump:**
- Updated `build.gradle` version from `0.1.0` to `0.1.1`

**CHANGELOG.md restructured for workflow extraction:**
- Created new `[0.1.1]` section with proper format (`## [0.1.1] - 2025-11-03`)
- Moved content from `[Unreleased]` to `[0.1.1]` section:
  - Automated Release Process changes
  - Documentation Reorganization improvements
- Updated Version History with v0.1.1 entry and link
- Cleaned up `[Unreleased]` section to only contain planned features