### PR TITLE
fix(ci): add write permissions to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,10 @@ jobs:
     name: Publish plugin to Nextflow registry
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
+      actions: write
+      attestations: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Why
The publish workflow was failing with a 403 error when attempting to push git tags because the GitHub Actions bot lacked the necessary permissions. The default `GITHUB_TOKEN` has restricted permissions and requires explicit grants to write to the repository.

## What
- Added `permissions` block to the publish job with:
  - `contents: write` - Required to push tags and create releases
  - `actions: write` - Required for workflow metadata
  - `attestations: write` - Required for build attestations

This enables the automated release process to successfully:
- Create and push version tags
- Create GitHub releases with changelog notes
- Complete the full publish workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)