### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Thread-safe error logging with synchronized collections
 - Immutable configuration objects after initialization
 
-## [Unreleased]
+## [0.2.0] - 2025-11-10
 
 ### Added
 
@@ -134,6 +134,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Search, dark mode, mobile-responsive design
   - Automated deployment from `gh-pages` branch
   - Restructured docs with Getting Started, Usage, and API sections
+
+## [Unreleased]
 
 ### Planned
 
@@ -147,8 +149,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Version History
 
+- **[0.2.0]** - Documentation site with GitHub Pages
 - **[0.1.1]** - Release automation and documentation improvements
 - **[0.1.0]** - Initial release with automatic notifications, custom messages, and progressive configuration examples
 
+[0.2.0]: https://github.com/adamrtalbot/nf-slack/releases/tag/v0.2.0
 [0.1.1]: https://github.com/adamrtalbot/nf-slack/releases/tag/v0.1.1
 [0.1.0]: https://github.com/adamrtalbot/nf-slack/releases/tag/v0.1.0

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'io.nextflow.nextflow-plugin' version '1.0.0-beta.10'
 }
 
-version = '0.1.1'
+version = '0.2.0'
 
 nextflowPlugin {
     nextflowVersion = '24.10.0'


### PR DESCRIPTION
## Release v0.2.0

### Changes

This release adds a comprehensive documentation site using MkDocs Material theme:

- **Documentation Site**: GitHub Pages site with MkDocs Material theme
  - Live documentation at https://adamrtalbot.github.io/nf-slack/
  - Search, dark mode, mobile-responsive design
  - Automated deployment from `gh-pages` branch
  - Restructured docs with Getting Started, Usage, and API sections

### Release Automation

When this PR is merged to `main`, the GitHub Actions workflow will automatically:

- ✅ Publish plugin to Nextflow Plugin Registry
- ✅ Create git tag `v0.2.0`
- ✅ Create GitHub release with changelog notes

### Checklist

- [x] Version updated in `build.gradle`
- [x] CHANGELOG.md updated with release notes
- [x] Tests passing
- [x] Documentation updated (if needed)