### PR TITLE
build: add run target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,7 @@ install:
 # Publish the plugin
 release:
 	./gradlew releasePlugin
+
+run:
+	./gradlew install
+	cd example && nextflow run .

--- a/test.sh
+++ b/test.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -e
-
-# Install the plugin
-./gradlew install
-
-# Run the example workflow
-cd example
-nextflow run .


### PR DESCRIPTION
## Why
Developers need a convenient way to test the plugin locally. Previously, this required running a separate shell script (`test.sh`).

## What
- Added `make run` target to install plugin and execute example workflow
- Removed redundant `test.sh` script
- Consolidated development workflow into Makefile

🤖 Generated with [Claude Code](https://claude.com/claude-code)