### PR TITLE
chore: Update references to seqeralabs organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,7 +130,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Documentation Site**: GitHub Pages site with MkDocs Material theme
-  - Live documentation at https://adamrtalbot.github.io/nf-slack/
+  - Live documentation at https://seqeralabs.github.io/nf-slack/
   - Search, dark mode, mobile-responsive design
   - Automated deployment from `gh-pages` branch
   - Restructured docs with Getting Started, Usage, and API sections
@@ -139,13 +139,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **CI/CD**: Prevent docs deployment race conditions ([#15](https://github.com/adamrtalbot/nf-slack/pull/15))
+- **CI/CD**: Prevent docs deployment race conditions ([#15](https://github.com/seqeralabs/nf-slack/pull/15))
   - Fixed race condition in GitHub Actions workflow when deploying documentation
   - Ensures stable and reliable documentation deployments to GitHub Pages
 
 ### Changed
 
-- **Build System**: Add run target to Makefile ([#14](https://github.com/adamrtalbot/nf-slack/pull/14))
+- **Build System**: Add run target to Makefile ([#14](https://github.com/seqeralabs/nf-slack/pull/14))
   - New `make run` target for easier local testing of example workflows
   - Simplifies development workflow for contributors
 
@@ -168,7 +168,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **[0.1.1]** - Release automation and documentation improvements
 - **[0.1.0]** - Initial release with automatic notifications, custom messages, and progressive configuration examples
 
-[0.2.1]: https://github.com/adamrtalbot/nf-slack/releases/tag/v0.2.1
-[0.2.0]: https://github.com/adamrtalbot/nf-slack/releases/tag/v0.2.0
-[0.1.1]: https://github.com/adamrtalbot/nf-slack/releases/tag/v0.1.1
-[0.1.0]: https://github.com/adamrtalbot/nf-slack/releases/tag/v0.1.0
+[0.2.1]: https://github.com/seqeralabs/nf-slack/releases/tag/v0.2.1
+[0.2.0]: https://github.com/seqeralabs/nf-slack/releases/tag/v0.2.0
+[0.1.1]: https://github.com/seqeralabs/nf-slack/releases/tag/v0.1.1
+[0.1.0]: https://github.com/seqeralabs/nf-slack/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Get Slack notifications for your Nextflow workflows - automatically notified when pipelines start, complete, or fail.
 
-:book: Full documentation: <https://adamrtalbot.github.io/nf-slack/>
+:book: Full documentation: <https://seqeralabs.github.io/nf-slack/>
 
 > [!IMPORTANT]
 > This is an open-source project for community benefit. It is provided as-is and is not part of Seqera's officially supported toolset.
@@ -204,8 +204,8 @@ We provide 6 progressive configuration examples from basic to advanced:
 
 ## Support
 
-- 🐛 [Report bugs](https://github.com/adamrtalbot/nf-slack/issues)
-- 💡 [Request features](https://github.com/adamrtalbot/nf-slack/issues)
+- 🐛 [Report bugs](https://github.com/seqeralabs/nf-slack/issues)
+- 💡 [Request features](https://github.com/seqeralabs/nf-slack/issues)
 - 📖 [Read the docs](docs/)
 
 ## License

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -105,6 +105,6 @@ Custom styles are in `stylesheets/extra.css`. The theme uses:
 
 ## Links
 
-- [Live Documentation](https://adamrtalbot.github.io/nf-slack/)
+- [Live Documentation](https://seqeralabs.github.io/nf-slack/)
 - [MkDocs Material Documentation](https://squidfunk.github.io/mkdocs-material/)
 - [Mike Versioning Documentation](https://github.com/jimporter/mike)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -133,5 +133,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **[0.1.1]** - Release automation and documentation improvements
 - **[0.1.0]** - Initial release with automatic notifications, custom messages, and progressive configuration examples
 
-[0.1.1]: https://github.com/adamrtalbot/nf-slack/releases/tag/v0.1.1
-[0.1.0]: https://github.com/adamrtalbot/nf-slack/releases/tag/v0.1.0
+[0.1.1]: https://github.com/seqeralabs/nf-slack/releases/tag/v0.1.1
+[0.1.0]: https://github.com/seqeralabs/nf-slack/releases/tag/v0.1.0

--- a/docs/examples/gallery.md
+++ b/docs/examples/gallery.md
@@ -53,7 +53,7 @@ Configuration examples are run by applying them to any workflow:
 
 ```bash
 # Clone the repository
-git clone https://github.com/adamrtalbot/nf-slack.git
+git clone https://github.com/seqeralabs/nf-slack.git
 cd nf-slack
 
 # Run with a configuration example
@@ -669,7 +669,7 @@ workflow {
 
 ## All Example Files
 
-All example files are available in the [nf-slack repository](https://github.com/adamrtalbot/nf-slack/tree/main/example):
+All example files are available in the [nf-slack repository](https://github.com/seqeralabs/nf-slack/tree/main/example):
 
 - Configuration examples: `example/configs/`
 - Script examples: `example/scripts/`

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -63,7 +63,7 @@ If you want to install a local development version of the plugin:
 1. **Clone the repository**
 
    ```bash
-   git clone https://github.com/adamrtalbot/nf-slack.git
+   git clone https://github.com/seqeralabs/nf-slack.git
    cd nf-slack
    ```
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -94,4 +94,4 @@ Now that you have basic notifications working, learn how to:
 ## Need Help?
 
 - Review the [API Reference](../reference/api.md)
-- [Open an issue](https://github.com/adamrtalbot/nf-slack/issues) on GitHub
+- [Open an issue](https://github.com/seqeralabs/nf-slack/issues) on GitHub

--- a/docs/index.md
+++ b/docs/index.md
@@ -125,9 +125,9 @@ workflow {
 
 ## Support
 
-- 🐛 [Report bugs](https://github.com/adamrtalbot/nf-slack/issues)
-- 💡 [Request features](https://github.com/adamrtalbot/nf-slack/issues)
-- 📖 [Read the docs](https://adamrtalbot.github.io/nf-slack/)
+- 🐛 [Report bugs](https://github.com/seqeralabs/nf-slack/issues)
+- 💡 [Request features](https://github.com/seqeralabs/nf-slack/issues)
+- 📖 [Read the docs](https://seqeralabs.github.io/nf-slack/)
 
 ## License
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: nf-slack
-repo_name: adamrtalbot/nf-slack
-repo_url: https://github.com/adamrtalbot/nf-slack
-site_url: https://adamrtalbot.github.io/nf-slack/latest/
+repo_name: seqeralabs/nf-slack
+repo_url: https://github.com/seqeralabs/nf-slack
+site_url: https://seqeralabs.github.io/nf-slack/latest/
 edit_uri: edit/main/docs/
 
 nav:
@@ -95,6 +95,6 @@ extra:
     provider: mike
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/adamrtalbot/nf-slack
+      link: https://github.com/seqeralabs/nf-slack
     - icon: fontawesome/brands/slack
       link: https://www.nextflow.io/slack.html


### PR DESCRIPTION
Updates all references in documentation and configuration files from 'adamrtalbot' to 'seqeralabs' following the repository move.