### PR TITLE
Release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-02-19
+
+### Fixed
+
+- Documentation admonition fixes
+- Clarified required bot roles in documentation
+
 ## [0.5.0] - 2026-02-18
 
 ### Added
@@ -239,6 +246,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Version History
 
+- **[0.5.1]** - Documentation admonition fixes, clarified required bot roles
 - **[0.5.0]** - Seqera Platform deep links, progress updates, emoji reactions, connection validation, bug fixes
 - **[0.4.0]** - File upload support, config-based uploads, remote file support
 - **[0.3.1]** - Documentation updates for bot support and threading features
@@ -248,6 +256,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **[0.1.1]** - Release automation and documentation improvements
 - **[0.1.0]** - Initial release with automatic notifications, custom messages, and progressive configuration examples
 
+[0.5.1]: https://github.com/seqeralabs/nf-slack/releases/tag/v0.5.1
 [0.5.0]: https://github.com/seqeralabs/nf-slack/releases/tag/v0.5.0
 [0.4.0]: https://github.com/seqeralabs/nf-slack/releases/tag/v0.4.0
 [0.3.1]: https://github.com/seqeralabs/nf-slack/releases/tag/v0.3.1

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add to your `nextflow.config`:
 
 ```groovy
 plugins {
-    id 'nf-slack@0.5.0'
+    id 'nf-slack@0.5.1'
 }
 
 slack {

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'io.nextflow.nextflow-plugin' version '1.0.0-beta.12'
 }
 
-version = '0.5.0'
+version = '0.5.1'
 
 nextflowPlugin {
     nextflowVersion = '24.10.0'

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Thank you for your interest in contributing to nf-slack! This document provides 
 5. **Test with Nextflow**
 
    ```bash
-   nextflow run hello -plugins nf-slack@0.5.0 // Make sure to have the correct version!
+   nextflow run hello -plugins nf-slack@0.5.1 // Make sure to have the correct version!
    ```
 
 ## Development Workflow

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -100,7 +100,7 @@ Add nf-slack to your `nextflow.config`:
 
 ```groovy
 plugins {
-    id 'nf-slack@0.5.0'
+    id 'nf-slack@0.5.1'
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ Slack notifications for your Nextflow workflows. Get notified when pipelines sta
 
 ```groovy
 plugins {
-    id 'nf-slack@0.5.0'
+    id 'nf-slack@0.5.1'
 }
 
 slack {

--- a/example/configs/01-minimal.config
+++ b/example/configs/01-minimal.config
@@ -1,5 +1,5 @@
 plugins {
-    id 'nf-slack@0.5.0'
+    id 'nf-slack@0.5.1'
 }
 
 slack {

--- a/example/configs/02-notification-control.config
+++ b/example/configs/02-notification-control.config
@@ -1,5 +1,5 @@
 plugins {
-    id 'nf-slack@0.5.0'
+    id 'nf-slack@0.5.1'
 }
 
 slack {

--- a/example/configs/03-message-text.config
+++ b/example/configs/03-message-text.config
@@ -1,5 +1,5 @@
 plugins {
-    id 'nf-slack@0.5.0'
+    id 'nf-slack@0.5.1'
 }
 
 slack {

--- a/example/configs/04-custom-fields.config
+++ b/example/configs/04-custom-fields.config
@@ -1,5 +1,5 @@
 plugins {
-    id 'nf-slack@0.5.0'
+    id 'nf-slack@0.5.1'
 }
 
 slack {

--- a/example/configs/05-selective-fields.config
+++ b/example/configs/05-selective-fields.config
@@ -1,5 +1,5 @@
 plugins {
-    id 'nf-slack@0.5.0'
+    id 'nf-slack@0.5.1'
 }
 
 slack {

--- a/example/configs/06-threaded-messages.config
+++ b/example/configs/06-threaded-messages.config
@@ -1,5 +1,5 @@
 plugins {
-    id 'nf-slack@0.5.0'
+    id 'nf-slack@0.5.1'
 }
 
 slack {

--- a/example/configs/07-file-upload.config
+++ b/example/configs/07-file-upload.config
@@ -1,5 +1,5 @@
 plugins {
-    id 'nf-slack@0.5.0'
+    id 'nf-slack@0.5.1'
 }
 
 slack {

--- a/example/nextflow.config
+++ b/example/nextflow.config
@@ -3,7 +3,7 @@
  */
 
 plugins {
-    id 'nf-slack@0.5.0'
+    id 'nf-slack@0.5.1'
 }
 
 // Slack configuration


### PR DESCRIPTION
## Release v0.5.1

### Changes

- **Fixed**: Documentation admonition formatting issues
- **Fixed**: Clarified required bot roles in documentation

### Files Updated

- `build.gradle` — version bumped to `0.5.1`
- `README.md`, `docs/index.md`, `docs/CONTRIBUTING.md`, `docs/getting-started/setup.md` — version references
- `example/nextflow.config`, `example/configs/01-07` — plugin version references
- `CHANGELOG.md` — release notes for v0.5.1

### Release Automation

When this PR is merged to `main`, the GitHub Actions workflow will automatically:

- ✅ Publish plugin to Nextflow Plugin Registry
- ✅ Create git tag `v0.5.1`
- ✅ Create GitHub release with changelog notes

### Checklist

- [x] Version updated in `build.gradle`
- [x] Version references updated in documentation files
- [x] CHANGELOG.md updated with release notes
- [ ] Tests passing
- [ ] Documentation updated (if needed)