### PR TITLE
feat: add failOnError option to abort pipeline on notification failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `slack.failOnError` option to abort the pipeline when Slack notification operations fail ([#54](https://github.com/seqeralabs/nf-slack/pull/54))
+
 ## [0.5.1] - 2026-02-19
 
 ### Fixed

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -23,6 +23,7 @@ Complete API reference for nf-slack plugin configuration options and functions.
 | `onComplete`        | Closure | See [`slack.onComplete`](#slackoncomplete) | No       | Configuration for workflow completion notifications                |
 | `onError`           | Closure | See [`slack.onError`](#slackonerror)       | No       | Configuration for workflow error notifications                     |
 | `validateOnStartup` | Boolean | `true`                                     | No       | Validate Slack connection credentials on pipeline startup          |
+| `failOnError`       | Boolean | `false`                                    | No       | Abort the pipeline when a Slack notification operation fails       |
 
 \*Either `webhook` or `bot` is required. If neither is configured, the plugin will automatically disable itself.
 

--- a/docs/usage/guide.md
+++ b/docs/usage/guide.md
@@ -351,6 +351,22 @@ slack {
 
 This checks the token/webhook and channel access at pipeline start, failing fast if there's a configuration problem.
 
+## Fail on Notification Errors
+
+By default, Slack notification failures are logged and the pipeline continues. Set `failOnError = true` to abort the pipeline when any notification operation fails (messages, file uploads, reactions, or extension calls):
+
+```groovy
+slack {
+    bot {
+        token = System.getenv('SLACK_BOT_TOKEN')
+        channel = 'general'
+    }
+    failOnError = true
+}
+```
+
+Reaction failures continue to log at `DEBUG` when `failOnError` is `false` (the default).
+
 ## What's Next
 
 - [Examples](../examples/gallery.md) — Copy-paste configurations for common scenarios

--- a/example/configs/01-minimal.config
+++ b/example/configs/01-minimal.config
@@ -4,6 +4,7 @@ plugins {
 
 slack {
     enabled = true
+    // failOnError = true  // Uncomment to abort the pipeline on notification failures
     bot {
         token = System.getenv('SLACK_BOT_TOKEN')
         channel = System.getenv('SLACK_CHANNEL_ID')

--- a/src/main/groovy/nextflow/slack/BotSlackSender.groovy
+++ b/src/main/groovy/nextflow/slack/BotSlackSender.groovy
@@ -491,12 +491,19 @@ class BotSlackSender implements SlackSender {
                         log.debug "Slack plugin: Reaction '${emoji}' ${action} skipped: ${response.error}"
                     } else {
                         def hint = response.error == 'missing_scope' ? ' (add reactions:write scope to your Slack app)' : ''
-                        log.warn "Slack plugin: Failed to ${action} reaction '${emoji}': ${response.error}${hint}"
+                        throw new RuntimeException("Slack plugin: Failed to ${action} reaction '${emoji}': ${response.error}${hint}")
                     }
                 }
             } else {
-                log.debug "Slack plugin: Failed to ${action} reaction - HTTP ${responseCode}"
+                def errorBody = connection.errorStream?.text ?: 'No error details'
+                throw new RuntimeException("Slack plugin: Failed to ${action} reaction - HTTP ${responseCode}: ${errorBody}")
             }
+        }
+        catch (RuntimeException e) {
+            throw e
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Slack plugin: Error ${action} reaction '${emoji}': ${e.message}", e)
         } finally {
             connection?.disconnect()
         }

--- a/src/main/groovy/nextflow/slack/SlackConfig.groovy
+++ b/src/main/groovy/nextflow/slack/SlackConfig.groovy
@@ -90,6 +90,12 @@ class SlackConfig {
     final boolean validateOnStartup
 
     /**
+     * If true, throw an exception (aborting the pipeline) when a Slack notification fails.
+     * Default: false (log warning and continue)
+     */
+    final boolean failOnError
+
+    /**
      * Configuration for workflow start notifications
      */
     final OnStartConfig onStart
@@ -130,6 +136,7 @@ class SlackConfig {
         this.botChannel = botConfig?.channel as String
         this.useThreads = botConfig?.useThreads != null ? botConfig.useThreads as boolean : true
         this.validateOnStartup = config.validateOnStartup != null ? config.validateOnStartup as boolean : true
+        this.failOnError = config.failOnError != null ? config.failOnError as boolean : false
         this.onStart = new OnStartConfig(config.onStart as Map)
         this.onComplete = new OnCompleteConfig(config.onComplete as Map)
         this.onError = new OnErrorConfig(config.onError as Map)
@@ -234,6 +241,7 @@ class SlackConfig {
         return "SlackConfig[enabled=${enabled}, " +
                "webhook=${webhook ? '***configured***' : 'null'}, " +
                "botToken=${botToken ? '***configured***' : 'null'}, " +
+               "failOnError=${failOnError}, " +
                "onStart=${onStart}, onComplete=${onComplete}, onError=${onError}]"
     }
 }

--- a/src/main/groovy/nextflow/slack/SlackExtension.groovy
+++ b/src/main/groovy/nextflow/slack/SlackExtension.groovy
@@ -56,20 +56,20 @@ class SlackExtension extends PluginExtensionPoint {
      */
     @Function
     void slackMessage(String text) {
+        // Get the observer instance from factory
+        def observer = SlackFactory.observerInstance
+
+        if (!observer) {
+            log.debug "Slack plugin: Observer not initialized, skipping message"
+            return
+        }
+
+        if (!observer.sender || !observer.messageBuilder) {
+            log.debug "Slack plugin: Not configured, skipping message"
+            return
+        }
+
         try {
-            // Get the observer instance from factory
-            def observer = SlackFactory.observerInstance
-
-            if (!observer) {
-                log.debug "Slack plugin: Observer not initialized, skipping message"
-                return
-            }
-
-            if (!observer.sender || !observer.messageBuilder) {
-                log.debug "Slack plugin: Not configured, skipping message"
-                return
-            }
-
             // Get thread timestamp if threading is enabled
             def threadTs = null
             if (observer.config?.useThreads && observer.sender instanceof BotSlackSender) {
@@ -83,8 +83,11 @@ class SlackExtension extends PluginExtensionPoint {
             log.debug "Slack plugin: Sent custom text message"
 
         } catch (Exception e) {
-            log.error "Slack plugin: Error sending message: ${e.message}", e
-            // Don't propagate exception - never fail the workflow
+            def msg = "Slack plugin: Error sending message: ${e.message}"
+            log.error msg, e
+            if (observer.config?.failOnError) {
+                throw new RuntimeException(msg, e)
+            }
         }
     }
 
@@ -106,26 +109,26 @@ class SlackExtension extends PluginExtensionPoint {
      */
     @Function
     void slackMessage(Map options) {
+        // Validate required parameters
+        if (!options.message) {
+            log.error "Slack plugin: 'message' parameter is required for rich messages"
+            return
+        }
+
+        // Get the observer instance from factory
+        def observer = SlackFactory.observerInstance
+
+        if (!observer) {
+            log.debug "Slack plugin: Observer not initialized, skipping message"
+            return
+        }
+
+        if (!observer.sender || !observer.messageBuilder) {
+            log.debug "Slack plugin: Not configured, skipping message"
+            return
+        }
+
         try {
-            // Validate required parameters
-            if (!options.message) {
-                log.error "Slack plugin: 'message' parameter is required for rich messages"
-                return
-            }
-
-            // Get the observer instance from factory
-            def observer = SlackFactory.observerInstance
-
-            if (!observer) {
-                log.debug "Slack plugin: Observer not initialized, skipping message"
-                return
-            }
-
-            if (!observer.sender || !observer.messageBuilder) {
-                log.debug "Slack plugin: Not configured, skipping message"
-                return
-            }
-
             // Get thread timestamp if threading is enabled
             def threadTs = null
             if (observer.config?.useThreads && observer.sender instanceof BotSlackSender) {
@@ -139,8 +142,11 @@ class SlackExtension extends PluginExtensionPoint {
             log.debug "Slack plugin: Sent custom rich message"
 
         } catch (Exception e) {
-            log.error "Slack plugin: Error sending rich message: ${e.message}", e
-            // Don't propagate exception - never fail the workflow
+            def msg = "Slack plugin: Error sending rich message: ${e.message}"
+            log.error msg, e
+            if (observer.config?.failOnError) {
+                throw new RuntimeException(msg, e)
+            }
         }
     }
 
@@ -176,26 +182,26 @@ class SlackExtension extends PluginExtensionPoint {
      */
     @Function
     void slackFileUpload(Map options) {
+        // Validate required parameters
+        if (!options.file) {
+            log.error "Slack plugin: 'file' parameter is required for file upload"
+            return
+        }
+
+        // Get the observer instance from factory
+        def observer = SlackFactory.observerInstance
+
+        if (!observer) {
+            log.debug "Slack plugin: Observer not initialized, skipping file upload"
+            return
+        }
+
+        if (!observer.sender) {
+            log.debug "Slack plugin: Not configured, skipping file upload"
+            return
+        }
+
         try {
-            // Validate required parameters
-            if (!options.file) {
-                log.error "Slack plugin: 'file' parameter is required for file upload"
-                return
-            }
-
-            // Get the observer instance from factory
-            def observer = SlackFactory.observerInstance
-
-            if (!observer) {
-                log.debug "Slack plugin: Observer not initialized, skipping file upload"
-                return
-            }
-
-            if (!observer.sender) {
-                log.debug "Slack plugin: Not configured, skipping file upload"
-                return
-            }
-
             // Resolve file path
             def file = options.file
             Path path
@@ -223,8 +229,11 @@ class SlackExtension extends PluginExtensionPoint {
             log.debug "Slack plugin: Uploaded file ${path.fileName}"
 
         } catch (Exception e) {
-            log.error "Slack plugin: Error uploading file: ${e.message}", e
-            // Don't propagate exception - never fail the workflow
+            def msg = "Slack plugin: Error uploading file: ${e.message}"
+            log.error msg, e
+            if (observer.config?.failOnError) {
+                throw new RuntimeException(msg, e)
+            }
         }
     }
 }

--- a/src/main/groovy/nextflow/slack/SlackObserver.groovy
+++ b/src/main/groovy/nextflow/slack/SlackObserver.groovy
@@ -295,7 +295,7 @@ class SlackObserver implements TraceObserver {
             }
         }
         catch (Exception e) {
-            handleNotificationError("add reaction '${emoji}'", e)
+            handleNotificationError("add reaction '${emoji}'", e, true)
         }
     }
 
@@ -315,7 +315,7 @@ class SlackObserver implements TraceObserver {
             }
         }
         catch (Exception e) {
-            handleNotificationError("remove reaction '${emoji}'", e)
+            handleNotificationError("remove reaction '${emoji}'", e, true)
         }
     }
 
@@ -338,11 +338,16 @@ class SlackObserver implements TraceObserver {
      * @param e The exception that caused the failure
      * @throws RuntimeException if failOnError is true
      */
-    private void handleNotificationError(String description, Exception e) {
+    private void handleNotificationError(String description, Exception e, boolean debugWhenNotFatal = false) {
         def msg = "Slack plugin: Failed to ${description}: ${e.message}"
-        log.warn msg
         if (config?.failOnError) {
+            log.warn msg
             throw new RuntimeException(msg, e)
+        }
+        if (debugWhenNotFatal) {
+            log.debug msg
+        } else {
+            log.warn msg
         }
     }
 

--- a/src/test/groovy/nextflow/slack/SlackClientTest.groovy
+++ b/src/test/groovy/nextflow/slack/SlackClientTest.groovy
@@ -34,22 +34,22 @@ class SlackClientTest extends Specification {
         sender != null
     }
 
-    def 'should handle null webhook URL gracefully'() {
+    def 'should throw when webhook URL is null'() {
         when:
         def sender = new WebhookSlackSender(null)
         sender.sendMessage('{"text":"test"}')
 
         then:
-        noExceptionThrown()
+        thrown(RuntimeException)
     }
 
-    def 'should handle invalid JSON gracefully'() {
+    def 'should throw when webhook delivery fails'() {
         when:
         def sender = new WebhookSlackSender('https://hooks.slack.com/services/TEST/TEST/TEST')
         sender.sendMessage('not valid json')
 
         then:
-        noExceptionThrown()
+        thrown(RuntimeException)
     }
 
     def 'should handle file upload gracefully with warning'() {

--- a/src/test/groovy/nextflow/slack/SlackConfigTest.groovy
+++ b/src/test/groovy/nextflow/slack/SlackConfigTest.groovy
@@ -497,4 +497,63 @@ class SlackConfigTest extends Specification {
         config.seqeraPlatform != null
         config.seqeraPlatform.enabled == false
     }
+
+    def 'should default failOnError to false'() {
+        given:
+        def session = Mock(Session)
+        session.config >> [
+            slack: [
+                webhook: [
+                    url: 'https://hooks.slack.com/services/TEST/TEST/TEST'
+                ]
+            ]
+        ]
+
+        when:
+        def config = SlackConfig.from(session)
+
+        then:
+        config != null
+        config.failOnError == false
+    }
+
+    def 'should parse failOnError when set to true'() {
+        given:
+        def session = Mock(Session)
+        session.config >> [
+            slack: [
+                webhook: [
+                    url: 'https://hooks.slack.com/services/TEST/TEST/TEST'
+                ],
+                failOnError: true
+            ]
+        ]
+
+        when:
+        def config = SlackConfig.from(session)
+
+        then:
+        config != null
+        config.failOnError == true
+    }
+
+    def 'should parse failOnError when set to false explicitly'() {
+        given:
+        def session = Mock(Session)
+        session.config >> [
+            slack: [
+                webhook: [
+                    url: 'https://hooks.slack.com/services/TEST/TEST/TEST'
+                ],
+                failOnError: false
+            ]
+        ]
+
+        when:
+        def config = SlackConfig.from(session)
+
+        then:
+        config != null
+        config.failOnError == false
+    }
 }

--- a/src/test/groovy/nextflow/slack/SlackExtensionTest.groovy
+++ b/src/test/groovy/nextflow/slack/SlackExtensionTest.groovy
@@ -281,4 +281,107 @@ class SlackExtensionTest extends Specification {
         cleanup:
         tempFile.delete()
     }
+
+    def 'should throw when slackMessage fails and failOnError is true'() {
+        given:
+        def mockBotSender = Mock(BotSlackSender)
+        def mockObserver = Mock(SlackObserver)
+        def mockMessageBuilder = Mock(SlackMessageBuilder)
+        def mockSession = Mock(Session)
+        mockSession.config >> [slack: [bot: [token: 'xoxb-test', channel: 'C123'], failOnError: true, validateOnStartup: false]]
+        def config = SlackConfig.from(mockSession)
+
+        mockObserver.sender >> mockBotSender
+        mockObserver.messageBuilder >> mockMessageBuilder
+        mockObserver.config >> config
+
+        SlackFactory.observerInstance = mockObserver
+        def extension = new SlackExtension()
+
+        when:
+        extension.slackMessage('Test message')
+
+        then:
+        1 * mockMessageBuilder.buildSimpleMessage('Test message', _) >> '{"text":"Test message"}'
+        1 * mockBotSender.sendMessage(_) >> { throw new IOException('network error') }
+        thrown(RuntimeException)
+    }
+
+    def 'should continue when slackMessage fails and failOnError is false'() {
+        given:
+        def mockBotSender = Mock(BotSlackSender)
+        def mockObserver = Mock(SlackObserver)
+        def mockMessageBuilder = Mock(SlackMessageBuilder)
+        def mockSession = Mock(Session)
+        mockSession.config >> [slack: [bot: [token: 'xoxb-test', channel: 'C123'], failOnError: false, validateOnStartup: false]]
+        def config = SlackConfig.from(mockSession)
+
+        mockObserver.sender >> mockBotSender
+        mockObserver.messageBuilder >> mockMessageBuilder
+        mockObserver.config >> config
+
+        SlackFactory.observerInstance = mockObserver
+        def extension = new SlackExtension()
+
+        when:
+        extension.slackMessage('Test message')
+
+        then:
+        1 * mockMessageBuilder.buildSimpleMessage('Test message', _) >> '{"text":"Test message"}'
+        1 * mockBotSender.sendMessage(_) >> { throw new IOException('network error') }
+        noExceptionThrown()
+    }
+
+    def 'should throw when rich slackMessage fails and failOnError is true'() {
+        given:
+        def mockBotSender = Mock(BotSlackSender)
+        def mockObserver = Mock(SlackObserver)
+        def mockMessageBuilder = Mock(SlackMessageBuilder)
+        def options = [message: 'Rich message']
+        def mockSession = Mock(Session)
+        mockSession.config >> [slack: [bot: [token: 'xoxb-test', channel: 'C123'], failOnError: true, validateOnStartup: false]]
+        def config = SlackConfig.from(mockSession)
+
+        mockObserver.sender >> mockBotSender
+        mockObserver.messageBuilder >> mockMessageBuilder
+        mockObserver.config >> config
+
+        SlackFactory.observerInstance = mockObserver
+        def extension = new SlackExtension()
+
+        when:
+        extension.slackMessage(options)
+
+        then:
+        1 * mockMessageBuilder.buildRichMessage(options, _) >> '{"blocks":[]}'
+        1 * mockBotSender.sendMessage(_) >> { throw new IOException('network error') }
+        thrown(RuntimeException)
+    }
+
+    def 'should throw when slackFileUpload fails and failOnError is true'() {
+        given:
+        def mockBotSender = Mock(BotSlackSender)
+        def mockObserver = Mock(SlackObserver)
+        def mockSession = Mock(Session)
+        mockSession.config >> [slack: [bot: [token: 'xoxb-test', channel: 'C123'], failOnError: true, validateOnStartup: false]]
+        def config = SlackConfig.from(mockSession)
+
+        mockObserver.sender >> mockBotSender
+        mockObserver.config >> config
+
+        SlackFactory.observerInstance = mockObserver
+        def extension = new SlackExtension()
+        def tempFile = File.createTempFile('test-fail', '.txt')
+        tempFile.text = 'test content'
+
+        when:
+        extension.slackFileUpload(tempFile.absolutePath)
+
+        then:
+        1 * mockBotSender.uploadFile(_, _) >> { throw new IOException('upload failed') }
+        thrown(RuntimeException)
+
+        cleanup:
+        tempFile.delete()
+    }
 }


### PR DESCRIPTION
Implements the `failOnError` configuration option requested in #45.

When `failOnError = true`, any Slack notification failure will throw a RuntimeException and abort the pipeline. When false (default), errors are logged as warnings and the pipeline continues.

Closes #45

Generated with [Claude Code](https://claude.ai/code)