### PR TITLE
feat: add deprecation warning for webhook support

### DIFF
--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -15,7 +15,7 @@ Get Slack notifications working with your Nextflow pipeline in minutes.
 
 ## 2. Configure Slack Credentials
 
-nf-slack supports two authentication methods. **Bot User is recommended** — it supports threading, emoji reactions, and file uploads.
+nf-slack supports two authentication methods. **Bot User is recommended** — it supports threading, emoji reactions, and file uploads. Webhook support is deprecated and will be removed before v1.0.0.
 
 === "Bot User (Recommended)"
 
@@ -48,6 +48,9 @@ nf-slack supports two authentication methods. **Bot User is recommended** — it
     ```
 
 === "Webhook"
+
+    !!! danger "Deprecated — will be removed before v1.0.0"
+        Webhook support is deprecated and will be removed in a future release. Please migrate to the **Bot User** configuration to continue receiving notifications and gain access to threading, emoji reactions, and file uploads.
 
     **Enable webhooks:**
 
@@ -117,7 +120,10 @@ Then add the Slack configuration block:
     }
     ```
 
-=== "Webhook"
+=== "Webhook (Deprecated)"
+
+    !!! danger "Deprecated"
+        Webhook support will be removed before v1.0.0. Switch to the **Bot User** configuration above.
 
     ```groovy
     slack {

--- a/src/main/groovy/nextflow/slack/SlackConfig.groovy
+++ b/src/main/groovy/nextflow/slack/SlackConfig.groovy
@@ -193,6 +193,9 @@ class SlackConfig {
 
         def slackConfig = new SlackConfig(config)
         log.info "Slack plugin: Enabled with ${botToken ? 'Bot' : 'Webhook'} notifications"
+        if (webhook && !botToken) {
+            log.warn "Slack plugin: Webhook support is deprecated and will be removed before v1.0.0. Please migrate to bot token configuration — see https://seqeralabs.github.io/nf-slack/getting-started/setup/"
+        }
         return slackConfig
     }
 


### PR DESCRIPTION
Webhook support will be removed before v1.0.0. This PR adds:

- A runtime `log.warn` deprecation message in `SlackConfig.from()` when webhook configuration is detected, prompting users to migrate to bot token configuration
- Documentation deprecation notices on all Webhook tabs in the setup guide

Closes #47

Generated with [Claude Code](https://claude.ai/code)