### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md
+
+`nf-slack` is a Nextflow plugin (Groovy 3.x / Java 11+, Gradle build) that sends
+Slack notifications for Nextflow workflow lifecycle events. See `CLAUDE.md`,
+`README.md`, and `docs/CONTRIBUTING.md` for the standard developer workflow, and
+the `Makefile` for the canonical build/test/install/run commands.
+
+## Cursor Cloud specific instructions
+
+This repo has no long-running service. The "application" is the plugin, which is
+exercised by building + installing it and running a Nextflow pipeline that loads
+it. Standard commands live in the `Makefile` (`make assemble`, `make test`,
+`make install`, `make run`); prefer those.
+
+- **Lint**: `pre-commit run --all-files`. It is installed by the update script
+  to `~/.local/bin` (already added to `PATH` via `~/.bashrc`). The
+  `nextflow-lint` hook shells out to `nextflow`, and the Prettier hook downloads
+  a Node environment on its first run, so the initial lint run needs network.
+- **Run / hello-world**: build and install the plugin first (`make install`),
+  then run a pipeline with `nextflow run <script> -plugins nf-slack@<version>`.
+  The `@<version>` must match `version` in `build.gradle` (e.g. `0.5.1`); the
+  locally installed plugin lives in `~/.nextflow/plugins/`.
+- **Testing the send path without real Slack credentials**: if neither a webhook
+  URL nor a bot token is configured, the plugin silently disables itself
+  (`SlackConfig.from` returns `null`). To exercise the notification code end to
+  end without credentials, point `slack.webhook.url` at a local HTTP server that
+  returns `200` (the webhook sender treats `200` as success) and set
+  `slack.validateOnStartup = false`.
+- **Benign warnings**: `WARN: Unrecognized config option 'slack.*'` printed
+  during `nextflow run` is expected. Nextflow has no schema for the plugin's
+  `slack { ... }` config namespace; the plugin still reads these values
+  correctly.
+- **Versions**: the VM has Java 21 and a recent Nextflow on `PATH`, which work
+  for development. CI is the source of truth for the supported matrix (Java
+  17/21, Nextflow 25.04/25.10) — see `.github/workflows/ci.yml`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for the `nf-slack` Nextflow plugin, and documents durable, non-obvious dev guidance for future Cursor Cloud agents in a new `AGENTS.md`.

No application/source code was modified — only `AGENTS.md` is added.

## Environment setup

- Installed the **Nextflow** runtime (one-off, snapshot-persisted) — the plugin's runtime.
- Installed **pre-commit** (lint tooling, mirrors CI).
- Update script refreshes Gradle dependencies and pre-commit on startup.

## Verification (all green)

| Step    | Command                                                         | Result |
| ------- | -------------------------------------------------------------- | ------ |
| Build   | `make assemble`                                                | ✅ BUILD SUCCESSFUL |
| Test    | `make test`                                                    | ✅ 139 tests, 0 failures |
| Lint    | `pre-commit run --all-files`                                   | ✅ all hooks passed |
| Install | `make install`                                                 | ✅ `nf-slack-0.5.1` installed |
| Run     | `nextflow run main.nf -plugins nf-slack@0.5.1 -c <webhook>`    | ✅ pipeline completed, 2 Slack notifications delivered |

## Hello-world

Ran the example pipeline with the plugin loaded, pointing `slack.webhook.url` at a local mock HTTP server (returns `200`). The plugin delivered both a **Pipeline started** and a **Pipeline completed successfully** notification with full Slack Block Kit payloads (run name, work dir, command line, duration, status, task counts) — exercising the core notification-send path end to end without real Slack credentials.

[nextflow_run.log](https://cursor.com/agents/bc-ca5a4f0e-3992-4053-afe5-beb14a6f94aa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnextflow_run.log)
[slack_webhook_payloads.log](https://cursor.com/agents/bc-ca5a4f0e-3992-4053-afe5-beb14a6f94aa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fslack_webhook_payloads.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca5a4f0e-3992-4053-afe5-beb14a6f94aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca5a4f0e-3992-4053-afe5-beb14a6f94aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

