### PR TITLE
Update default Nextflow version to 26.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         java_version: [17, 21]
-        nextflow_version: ["25.04", "25.10"]
+        nextflow_version: ["25.10", "26.04"]
 
     steps:
       - name: Environment

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -12,10 +12,11 @@ on:
       nextflow_version:
         description: "Nextflow version to test"
         required: false
-        default: "25.10"
+        default: "26.04"
         type: choice
         options:
           - "25.10"
+          - "26.04"
       java_version:
         description: "Java version to use"
         required: false

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         java_version: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('[{0}]', github.event.inputs.java_version)) || fromJSON('[21]') }}
-        nextflow_version: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', github.event.inputs.nextflow_version)) || fromJSON('["25.10"]') }}
+        nextflow_version: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', github.event.inputs.nextflow_version)) || fromJSON('["26.04"]') }}
 
     steps:
       - name: Environment

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,4 +32,4 @@ it. Standard commands live in the `Makefile` (`make assemble`, `make test`,
   correctly.
 - **Versions**: the VM has Java 21 and a recent Nextflow on `PATH`, which work
   for development. CI is the source of truth for the supported matrix (Java
-  17/21, Nextflow 25.04/25.10) — see `.github/workflows/ci.yml`.
+  17/21, Nextflow 25.10/26.04) — see `.github/workflows/ci.yml`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Raised minimum supported Nextflow version to 25.10.0; CI now tests 25.10 and 26.04 ([#72](https://github.com/seqeralabs/nf-slack/pull/72))
+
 ## [0.5.1] - 2026-02-19
 
 ### Fixed

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 version = '0.5.1'
 
 nextflowPlugin {
-    nextflowVersion = '24.10.0'
+    nextflowVersion = '25.10.0'
 
     provider = 'Seqera'
     description = 'Get Slack notifications from your Nextflow workflows'

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thank you for your interest in contributing to nf-slack! This document provides 
 
 - Java 11 or higher
 - Gradle (wrapper included)
-- Nextflow 25.04.0 or higher
+- Nextflow 25.10.0 or higher
 - A Slack workspace with admin access for testing
 
 ### Development Setup

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -4,7 +4,7 @@ Get Slack notifications working with your Nextflow pipeline in minutes.
 
 ## Prerequisites
 
-- Nextflow v25.04.0 or later
+- Nextflow v25.10.0 or later
 - A Slack workspace where you have permission to add apps
 
 ## 1. Create a Slack App


### PR DESCRIPTION
This pull request updates the minimum required Nextflow version across documentation and CI workflows to ensure consistency and support for newer features. The changes also update the default and available Nextflow versions in workflow configuration files.

**CI and workflow configuration updates:**

* Updated the Nextflow version matrix in `.github/workflows/ci.yml` to test against versions `25.10` and `26.04`, removing `25.04` from the matrix.
* Changed the default Nextflow version in `.github/workflows/example.yml` to `26.04` and added `26.04` to the list of selectable options.

**Documentation updates:**

* Updated the minimum required Nextflow version in `docs/CONTRIBUTING.md` and `docs/getting-started/setup.md` from `25.04.0` to `25.10.0` to reflect the new baseline. [[1]](diffhunk://#diff-4c6b93aa75d5affde60dc3849606c9acd75ed444d52e99f3055fc0c7aa77e9e0L11-R11) [[2]](diffhunk://#diff-527a8429a3b62b0c31ddad5438ca3255b640005ee4ed9566ac8727fe58205a2bL7-R7)