### PR TITLE
fix: show Seqera Platform button when watch URL is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Seqera Platform deep-link button now resolves `watchUrl` from the `observers` list used by Nextflow 24.10, in addition to `observersV1` and `observersV2` ([#73](https://github.com/seqeralabs/nf-slack/pull/73))
+
 ## [0.5.1] - 2026-02-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Seqera Platform deep-link button now resolves `watchUrl` from the `observers` list used by Nextflow 24.10, in addition to `observersV1` and `observersV2` ([#73](https://github.com/seqeralabs/nf-slack/pull/73))
+- Seqera Platform deep-link button now resolves the watch URL from `workflowMetadata.platform.workflowUrl` and from TowerClient/TowerObserver across all session observer lists (`observers`, `observersV1`, `observersV2`); polls until the URL is available before updating the start message; and includes the button on progress and completion messages ([#73](https://github.com/seqeralabs/nf-slack/pull/73))
 
 ## [0.5.1] - 2026-02-19
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 version = '0.5.1'
 
 nextflowPlugin {
-    nextflowVersion = '24.10.0'
+    nextflowVersion = '25.10.0'
 
     provider = 'Seqera'
     description = 'Get Slack notifications from your Nextflow workflows'

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 version = '0.5.1'
 
 nextflowPlugin {
-    nextflowVersion = '25.10.0'
+    nextflowVersion = '24.10.0'
 
     provider = 'Seqera'
     description = 'Get Slack notifications from your Nextflow workflows'

--- a/src/main/groovy/nextflow/slack/SlackMessageBuilder.groovy
+++ b/src/main/groovy/nextflow/slack/SlackMessageBuilder.groovy
@@ -230,7 +230,9 @@ class SlackMessageBuilder {
     }
 
     /**
-     * Find TowerClient or TowerObserver in any Nextflow session observer list.
+     * Find TowerClient or TowerObserver in any session observer list field.
+     * nf-tower may register in {@code observers}, {@code observersV1}, or
+     * {@code observersV2} depending on run context, not Nextflow version.
      */
     private Object findTowerObserver() {
         for (String fieldName : ['observers', 'observersV1', 'observersV2']) {

--- a/src/main/groovy/nextflow/slack/SlackMessageBuilder.groovy
+++ b/src/main/groovy/nextflow/slack/SlackMessageBuilder.groovy
@@ -211,9 +211,18 @@ class SlackMessageBuilder {
             if (target instanceof Map) {
                 return (target as Map).get(propertyName) as String
             }
-            def field = target.class.getDeclaredField(propertyName)
-            field.accessible = true
-            return field.get(target) as String
+            Class clazz = target.class
+            while (clazz) {
+                try {
+                    def field = clazz.getDeclaredField(propertyName)
+                    field.accessible = true
+                    return field.get(target) as String
+                }
+                catch (NoSuchFieldException ignored) {
+                    clazz = clazz.superclass
+                }
+            }
+            return org.codehaus.groovy.runtime.InvokerHelper.getPropertySafe(target, propertyName) as String
         }
         catch (Exception ignored) {
             return null

--- a/src/main/groovy/nextflow/slack/SlackMessageBuilder.groovy
+++ b/src/main/groovy/nextflow/slack/SlackMessageBuilder.groovy
@@ -193,7 +193,7 @@ class SlackMessageBuilder {
 
     private String readPlatformWorkflowUrl() {
         try {
-            def metadata = session.workflowMetadata
+            Object metadata = session.workflowMetadata
             if (!metadata) return null
             def platform = metadata instanceof Map
                 ? (metadata as Map).get('platform')

--- a/src/main/groovy/nextflow/slack/SlackMessageBuilder.groovy
+++ b/src/main/groovy/nextflow/slack/SlackMessageBuilder.groovy
@@ -149,12 +149,14 @@ class SlackMessageBuilder {
         ]
     }
 
+    private static final List<String> TOWER_OBSERVER_CLASS_NAMES = [
+        'io.seqera.tower.plugin.TowerClient',
+        'io.seqera.tower.plugin.TowerObserver'
+    ]
+
     /**
-     * Get Seqera Platform watch URL from TowerClient if deep links are enabled.
+     * Get Seqera Platform watch URL if deep links are enabled.
      * Returns null if unavailable — callers should skip the button.
-     *
-     * The URL is read directly from TowerClient's watchUrl field, which is the
-     * fully-resolved URL returned by the Seqera Platform API.
      */
     private String getSeqeraPlatformUrl() {
         if (!config.seqeraPlatform?.enabled) return null
@@ -165,32 +167,78 @@ class SlackMessageBuilder {
     }
 
     /**
-     * Retrieve the watch URL from TowerClient via reflection.
+     * Retrieve the Seqera Platform watch URL.
      *
-     * TowerClient is in a separate plugin (nf-tower) so we cannot reference it
-     * directly. We find it by class name in the session's observer list, then
-     * read its private watchUrl field.
+     * Prefers workflow metadata populated by nf-tower during onFlowBegin. Falls
+     * back to reading the private {@code watchUrl} field from TowerClient or
+     * TowerObserver (Nextflow 25.10+) via reflection on {@code observersV1} and
+     * {@code observersV2}.
      */
     // Package-private for testability (Spock Spy cannot stub private methods)
     String getTowerClientWatchUrl() {
         try {
-            def observersField = session.class.getDeclaredField('observersV2')
-            observersField.accessible = true
-            def observers = observersField.get(session) as List
+            def workflowUrl = readPlatformWorkflowUrl()
+            if (workflowUrl) return workflowUrl
 
-            def towerClient = observers?.find {
-                it.class.name == 'io.seqera.tower.plugin.TowerClient'
-            }
-            if (!towerClient) return null
+            def towerObserver = findTowerObserver()
+            if (!towerObserver) return null
 
-            def watchUrlField = towerClient.class.getDeclaredField('watchUrl')
-            watchUrlField.accessible = true
-            return watchUrlField.get(towerClient) as String
+            return readStringProperty(towerObserver, 'watchUrl')
         }
         catch (Exception e) {
             log.debug "Could not retrieve Seqera Platform watch URL: ${e.message}"
             return null
         }
+    }
+
+    private String readPlatformWorkflowUrl() {
+        try {
+            def metadata = session.workflowMetadata
+            if (!metadata) return null
+            def platform = metadata instanceof Map
+                ? (metadata as Map).get('platform')
+                : org.codehaus.groovy.runtime.InvokerHelper.getPropertySafe(metadata, 'platform')
+            return readStringProperty(platform, 'workflowUrl')
+        }
+        catch (Exception ignored) {
+            return null
+        }
+    }
+
+    private static String readStringProperty(Object target, String propertyName) {
+        if (!target) return null
+        try {
+            if (target instanceof Map) {
+                return (target as Map).get(propertyName) as String
+            }
+            def field = target.class.getDeclaredField(propertyName)
+            field.accessible = true
+            return field.get(target) as String
+        }
+        catch (Exception ignored) {
+            return null
+        }
+    }
+
+    /**
+     * Find TowerClient or TowerObserver in Nextflow 25.10+ session observer lists.
+     */
+    private Object findTowerObserver() {
+        for (String fieldName : ['observersV1', 'observersV2']) {
+            try {
+                def observersField = session.class.getDeclaredField(fieldName)
+                observersField.accessible = true
+                def observers = observersField.get(session) as List
+
+                def towerObserver = observers?.find {
+                    TOWER_OBSERVER_CLASS_NAMES.contains(it.class.name)
+                }
+                if (towerObserver) return towerObserver
+            }
+            catch (NoSuchFieldException ignored) {
+            }
+        }
+        return null
     }
 
     /**
@@ -546,6 +594,11 @@ class SlackMessageBuilder {
             blocks << createContextFooter(status, timestamp, workflowName)
         }
 
+        def seqeraUrl = getSeqeraPlatformUrl()
+        if (seqeraUrl) {
+            blocks << createSeqeraPlatformButton(seqeraUrl)
+        }
+
         return createMessagePayload(blocks, threadTs)
     }
 
@@ -630,6 +683,11 @@ class SlackMessageBuilder {
         }
         fields.add(createMarkdownField('Elapsed', elapsed))
         blocks.add(createFieldsSection(fields))
+
+        def seqeraUrl = getSeqeraPlatformUrl()
+        if (seqeraUrl) {
+            blocks.add(createSeqeraPlatformButton(seqeraUrl))
+        }
 
         return createMessagePayload(blocks, threadTs)
     }

--- a/src/main/groovy/nextflow/slack/SlackMessageBuilder.groovy
+++ b/src/main/groovy/nextflow/slack/SlackMessageBuilder.groovy
@@ -171,7 +171,7 @@ class SlackMessageBuilder {
      *
      * Prefers workflow metadata populated by nf-tower during onFlowBegin. Falls
      * back to reading the private {@code watchUrl} field from TowerClient or
-     * TowerObserver (Nextflow 25.10+) via reflection on {@code observersV1} and
+     * TowerObserver via reflection on {@code observers}, {@code observersV1}, and
      * {@code observersV2}.
      */
     // Package-private for testability (Spock Spy cannot stub private methods)
@@ -221,10 +221,10 @@ class SlackMessageBuilder {
     }
 
     /**
-     * Find TowerClient or TowerObserver in Nextflow 25.10+ session observer lists.
+     * Find TowerClient or TowerObserver in any Nextflow session observer list.
      */
     private Object findTowerObserver() {
-        for (String fieldName : ['observersV1', 'observersV2']) {
+        for (String fieldName : ['observers', 'observersV1', 'observersV2']) {
             try {
                 def observersField = session.class.getDeclaredField(fieldName)
                 observersField.accessible = true

--- a/src/main/groovy/nextflow/slack/SlackObserver.groovy
+++ b/src/main/groovy/nextflow/slack/SlackObserver.groovy
@@ -136,9 +136,8 @@ class SlackObserver implements TraceObserver {
     /**
      * Called when the workflow execution begins (after setup, before processes run).
      *
-     * V1 observers (like us) are called before V2 observers (like TowerClient),
-     * so the Seqera Platform watch URL isn't available yet. We schedule an async
-     * update to add the deep link button once TowerClient has completed setup.
+     * TowerClient/TowerObserver sets its watchUrl during onFlowBegin.
+     * We schedule an async update to add the deep link button once the URL is available.
      */
     @Override
     void onFlowBegin() {
@@ -152,27 +151,39 @@ class SlackObserver implements TraceObserver {
 
     /**
      * Schedule an async update to add the Seqera Platform button to the start message.
-     * Waits briefly for TowerClient (a V2 observer) to set its watchUrl during onFlowBegin.
+     * Polls until the watch URL is available or max attempts is reached.
      */
+    private static final long SEQERA_BUTTON_POLL_INTERVAL_MS = 2000L
+    private static final int SEQERA_BUTTON_MAX_ATTEMPTS = 15
+
     private void scheduleSeqeraPlatformButtonUpdate() {
         if (!config.seqeraPlatform?.enabled) return
         if (!(sender instanceof BotSlackSender)) return
         def messageTs = (sender as BotSlackSender).getThreadTs()
         if (!messageTs) return
 
+        scheduleSeqeraPlatformButtonUpdateAttempt(messageTs, 0)
+    }
+
+    private void scheduleSeqeraPlatformButtonUpdateAttempt(String messageTs, int attempt) {
+        long delay = attempt == 0 ? 1000L : SEQERA_BUTTON_POLL_INTERVAL_MS
         new Timer('slack-seqera-button', true).schedule(new TimerTask() {
             @Override
             void run() {
                 try {
-                    def startMessage = messageBuilder.buildWorkflowStartMessage()
-                    sender.updateMessage(startMessage, messageTs)
-                    log.debug "Slack plugin: Updated start message with Seqera Platform button"
+                    if (messageBuilder.getTowerClientWatchUrl()) {
+                        def startMessage = messageBuilder.buildWorkflowStartMessage()
+                        sender.updateMessage(startMessage, messageTs)
+                        log.debug "Slack plugin: Updated start message with Seqera Platform button"
+                    } else if (attempt + 1 < SEQERA_BUTTON_MAX_ATTEMPTS) {
+                        scheduleSeqeraPlatformButtonUpdateAttempt(messageTs, attempt + 1)
+                    }
                 }
                 catch (Exception e) {
                     log.debug "Slack plugin: Failed to update start message with Seqera Platform button: ${e.message}"
                 }
             }
-        }, 3000L)
+        }, delay)
     }
 
     /**

--- a/src/test/groovy/nextflow/slack/SlackMessageBuilderTest.groovy
+++ b/src/test/groovy/nextflow/slack/SlackMessageBuilderTest.groovy
@@ -709,9 +709,9 @@ class SlackMessageBuilderTest extends Specification {
         actionsBlock == null
     }
 
-    def 'should read TowerClient watchUrl from observers list (Nextflow 24.10)'() {
+    def 'should read TowerClient watchUrl from observersV1 list (Nextflow 25.10+)'() {
         given:
-        def gcl = new GroovyClassLoader()
+        def gcl = new GroovyClassLoader(this.class.classLoader)
         def towerClass = gcl.parseClass('''
             package io.seqera.tower.plugin
             class TowerClient {
@@ -719,22 +719,27 @@ class SlackMessageBuilderTest extends Specification {
             }
         ''')
         def towerClient = towerClass.newInstance()
-        def session = new Session([:])
-        def observersField = Session.class.getDeclaredField('observers')
-        observersField.accessible = true
-        observersField.set(session, [towerClient])
+        def sessionClass = gcl.parseClass('''
+            import nextflow.Session
+            class FakeSession extends Session {
+                java.util.List observersV1
+                FakeSession() { super([:]) }
+            }
+        ''')
+        def session = sessionClass.newInstance()
+        session.observersV1 = [towerClient]
 
         def platformConfig = new SlackConfig([
             webhook: 'https://hooks.slack.com/test',
             seqeraPlatform: [enabled: true]
         ])
-        def builder = new SlackMessageBuilder(platformConfig, session)
+        def builder = new SlackMessageBuilder(platformConfig, session as Session)
 
         expect:
         builder.getTowerClientWatchUrl() == 'https://cloud.seqera.io/orgs/myorg/workspaces/myws/watch/abc123'
     }
 
-    def 'should read TowerObserver watchUrl from observersV1 list (Nextflow 25.x+)'() {
+    def 'should read TowerObserver watchUrl from observersV1 list (Nextflow 25.10+)'() {
         given:
         def gcl = new GroovyClassLoader(this.class.classLoader)
         def towerClass = gcl.parseClass('''
@@ -762,6 +767,34 @@ class SlackMessageBuilderTest extends Specification {
 
         expect:
         builder.getTowerClientWatchUrl() == 'https://cloud.seqera.io/orgs/myorg/workspaces/myws/watch/xyz789'
+    }
+
+    def 'should include Seqera Platform button in complete message when watchUrl is available'() {
+        given:
+        def platformConfig = new SlackConfig([
+            webhook: 'https://hooks.slack.com/test',
+            seqeraPlatform: [enabled: true]
+        ])
+        def mockMetadata = Mock(WorkflowMetadata)
+        mockMetadata.scriptName >> 'test-workflow.nf'
+        mockMetadata.duration >> Duration.of('1h')
+        mockMetadata.stats >> null
+        def towerSession = Mock(Session)
+        towerSession.config >> [:]
+        towerSession.workflowMetadata >> mockMetadata
+        towerSession.runName >> 'crazy_einstein'
+        towerSession.uniqueId >> UUID.fromString('00000000-0000-0000-0000-000000000000')
+        def builder = Spy(new SlackMessageBuilder(platformConfig, towerSession))
+        builder.getTowerClientWatchUrl() >> 'https://cloud.seqera.io/orgs/myorg/workspaces/myws/watch/abc123'
+
+        when:
+        def message = builder.buildWorkflowCompleteMessage()
+        def json = new JsonSlurper().parseText(message)
+
+        then:
+        def actionsBlock = json.blocks.find { it.type == 'actions' }
+        actionsBlock != null
+        actionsBlock.elements[0].url == 'https://cloud.seqera.io/orgs/myorg/workspaces/myws/watch/abc123'
     }
 
     def 'should include Seqera Platform button in progress update when watchUrl is available'() {

--- a/src/test/groovy/nextflow/slack/SlackMessageBuilderTest.groovy
+++ b/src/test/groovy/nextflow/slack/SlackMessageBuilderTest.groovy
@@ -709,7 +709,7 @@ class SlackMessageBuilderTest extends Specification {
         actionsBlock == null
     }
 
-    def 'should read TowerClient watchUrl from observers list (Nextflow 24.10)'() {
+    def 'should read TowerClient watchUrl from observers list'() {
         given:
         def gcl = new GroovyClassLoader(this.class.classLoader)
         def towerClass = gcl.parseClass('''
@@ -739,7 +739,7 @@ class SlackMessageBuilderTest extends Specification {
         builder.getTowerClientWatchUrl() == 'https://cloud.seqera.io/orgs/myorg/workspaces/myws/watch/abc123'
     }
 
-    def 'should read TowerClient watchUrl from observersV1 list (Nextflow 25.10+)'() {
+    def 'should read TowerClient watchUrl from observersV1 list'() {
         given:
         def gcl = new GroovyClassLoader(this.class.classLoader)
         def towerClass = gcl.parseClass('''
@@ -769,7 +769,7 @@ class SlackMessageBuilderTest extends Specification {
         builder.getTowerClientWatchUrl() == 'https://cloud.seqera.io/orgs/myorg/workspaces/myws/watch/abc123'
     }
 
-    def 'should read TowerObserver watchUrl from observersV1 list (Nextflow 25.10+)'() {
+    def 'should read TowerObserver watchUrl from observersV1 list'() {
         given:
         def gcl = new GroovyClassLoader(this.class.classLoader)
         def towerClass = gcl.parseClass('''

--- a/src/test/groovy/nextflow/slack/SlackMessageBuilderTest.groovy
+++ b/src/test/groovy/nextflow/slack/SlackMessageBuilderTest.groovy
@@ -709,6 +709,36 @@ class SlackMessageBuilderTest extends Specification {
         actionsBlock == null
     }
 
+    def 'should read TowerClient watchUrl from observers list (Nextflow 24.10)'() {
+        given:
+        def gcl = new GroovyClassLoader(this.class.classLoader)
+        def towerClass = gcl.parseClass('''
+            package io.seqera.tower.plugin
+            class TowerClient {
+                private String watchUrl = 'https://cloud.seqera.io/orgs/myorg/workspaces/myws/watch/abc123'
+            }
+        ''')
+        def towerClient = towerClass.newInstance()
+        def sessionClass = gcl.parseClass('''
+            import nextflow.Session
+            class FakeSession extends Session {
+                java.util.List observers
+                FakeSession() { super([:]) }
+            }
+        ''')
+        def session = sessionClass.newInstance()
+        session.observers = [towerClient]
+
+        def platformConfig = new SlackConfig([
+            webhook: 'https://hooks.slack.com/test',
+            seqeraPlatform: [enabled: true]
+        ])
+        def builder = new SlackMessageBuilder(platformConfig, session as Session)
+
+        expect:
+        builder.getTowerClientWatchUrl() == 'https://cloud.seqera.io/orgs/myorg/workspaces/myws/watch/abc123'
+    }
+
     def 'should read TowerClient watchUrl from observersV1 list (Nextflow 25.10+)'() {
         given:
         def gcl = new GroovyClassLoader(this.class.classLoader)

--- a/src/test/groovy/nextflow/slack/SlackMessageBuilderTest.groovy
+++ b/src/test/groovy/nextflow/slack/SlackMessageBuilderTest.groovy
@@ -827,6 +827,56 @@ class SlackMessageBuilderTest extends Specification {
         actionsBlock.elements[0].url == 'https://cloud.seqera.io/orgs/myorg/workspaces/myws/watch/abc123'
     }
 
+    def 'should not include Seqera Platform button in complete message when watchUrl is null'() {
+        given:
+        def platformConfig = new SlackConfig([
+            webhook: 'https://hooks.slack.com/test',
+            seqeraPlatform: [enabled: true]
+        ])
+        def mockMetadata = Mock(WorkflowMetadata)
+        mockMetadata.scriptName >> 'test-workflow.nf'
+        mockMetadata.duration >> Duration.of('1h')
+        mockMetadata.stats >> null
+        def towerSession = Mock(Session)
+        towerSession.config >> [:]
+        towerSession.workflowMetadata >> mockMetadata
+        towerSession.runName >> 'crazy_einstein'
+        towerSession.uniqueId >> UUID.fromString('00000000-0000-0000-0000-000000000000')
+        def builder = Spy(new SlackMessageBuilder(platformConfig, towerSession))
+        builder.getTowerClientWatchUrl() >> null
+
+        when:
+        def message = builder.buildWorkflowCompleteMessage()
+        def json = new JsonSlurper().parseText(message)
+
+        then:
+        json.blocks.find { it.type == 'actions' } == null
+    }
+
+    def 'should not include Seqera Platform button in progress update when watchUrl is null'() {
+        given:
+        def platformConfig = new SlackConfig([
+            webhook: 'https://hooks.slack.com/test',
+            seqeraPlatform: [enabled: true]
+        ])
+        def mockMetadata = Mock(WorkflowMetadata)
+        mockMetadata.scriptName >> 'test-workflow.nf'
+        def towerSession = Mock(Session)
+        towerSession.config >> [:]
+        towerSession.workflowMetadata >> mockMetadata
+        towerSession.runName >> 'crazy_einstein'
+        towerSession.uniqueId >> UUID.fromString('00000000-0000-0000-0000-000000000000')
+        def builder = Spy(new SlackMessageBuilder(platformConfig, towerSession))
+        builder.getTowerClientWatchUrl() >> null
+
+        when:
+        def message = builder.buildProgressUpdateMessage(10, 5, 2, 0, 60000L, null)
+        def json = new JsonSlurper().parseText(message)
+
+        then:
+        json.blocks.find { it.type == 'actions' } == null
+    }
+
     def 'should include Seqera Platform button in progress update when watchUrl is available'() {
         given:
         def platformConfig = new SlackConfig([

--- a/src/test/groovy/nextflow/slack/SlackMessageBuilderTest.groovy
+++ b/src/test/groovy/nextflow/slack/SlackMessageBuilderTest.groovy
@@ -709,6 +709,87 @@ class SlackMessageBuilderTest extends Specification {
         actionsBlock == null
     }
 
+    def 'should read TowerClient watchUrl from observers list (Nextflow 24.10)'() {
+        given:
+        def gcl = new GroovyClassLoader()
+        def towerClass = gcl.parseClass('''
+            package io.seqera.tower.plugin
+            class TowerClient {
+                private String watchUrl = 'https://cloud.seqera.io/orgs/myorg/workspaces/myws/watch/abc123'
+            }
+        ''')
+        def towerClient = towerClass.newInstance()
+        def session = new Session([:])
+        def observersField = Session.class.getDeclaredField('observers')
+        observersField.accessible = true
+        observersField.set(session, [towerClient])
+
+        def platformConfig = new SlackConfig([
+            webhook: 'https://hooks.slack.com/test',
+            seqeraPlatform: [enabled: true]
+        ])
+        def builder = new SlackMessageBuilder(platformConfig, session)
+
+        expect:
+        builder.getTowerClientWatchUrl() == 'https://cloud.seqera.io/orgs/myorg/workspaces/myws/watch/abc123'
+    }
+
+    def 'should read TowerObserver watchUrl from observersV1 list (Nextflow 25.x+)'() {
+        given:
+        def gcl = new GroovyClassLoader(this.class.classLoader)
+        def towerClass = gcl.parseClass('''
+            package io.seqera.tower.plugin
+            class TowerObserver {
+                private String watchUrl = 'https://cloud.seqera.io/orgs/myorg/workspaces/myws/watch/xyz789'
+            }
+        ''')
+        def towerObserver = towerClass.newInstance()
+        def sessionClass = gcl.parseClass('''
+            import nextflow.Session
+            class FakeSession extends Session {
+                java.util.List observersV1
+                FakeSession() { super([:]) }
+            }
+        ''')
+        def session = sessionClass.newInstance()
+        session.observersV1 = [towerObserver]
+
+        def platformConfig = new SlackConfig([
+            webhook: 'https://hooks.slack.com/test',
+            seqeraPlatform: [enabled: true]
+        ])
+        def builder = new SlackMessageBuilder(platformConfig, session as Session)
+
+        expect:
+        builder.getTowerClientWatchUrl() == 'https://cloud.seqera.io/orgs/myorg/workspaces/myws/watch/xyz789'
+    }
+
+    def 'should include Seqera Platform button in progress update when watchUrl is available'() {
+        given:
+        def platformConfig = new SlackConfig([
+            webhook: 'https://hooks.slack.com/test',
+            seqeraPlatform: [enabled: true]
+        ])
+        def mockMetadata = Mock(WorkflowMetadata)
+        mockMetadata.scriptName >> 'test-workflow.nf'
+        def towerSession = Mock(Session)
+        towerSession.config >> [:]
+        towerSession.workflowMetadata >> mockMetadata
+        towerSession.runName >> 'crazy_einstein'
+        towerSession.uniqueId >> UUID.fromString('00000000-0000-0000-0000-000000000000')
+        def builder = Spy(new SlackMessageBuilder(platformConfig, towerSession))
+        builder.getTowerClientWatchUrl() >> 'https://cloud.seqera.io/orgs/myorg/workspaces/myws/watch/abc123'
+
+        when:
+        def message = builder.buildProgressUpdateMessage(10, 5, 2, 0, 60000L, null)
+        def json = new JsonSlurper().parseText(message)
+
+        then:
+        def actionsBlock = json.blocks.find { it.type == 'actions' }
+        actionsBlock != null
+        actionsBlock.elements[0].url == 'https://cloud.seqera.io/orgs/myorg/workspaces/myws/watch/abc123'
+    }
+
     // --- Config-level includeFields tests ---
 
     def 'should filter start message fields with config-level includeFields'() {


### PR DESCRIPTION
## Summary

Fixes missing "View in Seqera Platform" button ([#67](https://github.com/seqeralabs/nf-slack/issues/67)).

**Root cause (not Nextflow version):** The plugin only looked for `TowerClient` in `session.observersV2` and updated the start message once after a fixed 3s delay without checking whether the URL was ready. nf-tower can register `TowerClient`/`TowerObserver` in `observers`, `observersV1`, or `observersV2` depending on run context — the same Nextflow version (e.g. 26.04) can show or hide the button depending on where the observer lands and when the Platform API returns the watch URL.

**Fix:**
- Resolve watch URL from `workflowMetadata.platform.workflowUrl` first, then via reflection on all observer lists (`observers`, `observersV1`, `observersV2`)
- Poll until the URL is available (or max attempts) before updating the start message
- Add the Seqera button to progress and completion messages when a URL is available

Closes #67

## Test plan
- [x] `./gradlew test`
- [ ] Verify button appears on pipeline start after URL becomes available (Seqera Platform run)
- [ ] Verify button on complete and progress messages when running with nf-tower enabled