### PR TITLE
feat: contextual Seqera Platform action buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Seqera Platform action buttons**: Contextual Cancel, Resume, and Relaunch buttons alongside View in Seqera Platform. Link mode (default) opens the Platform run page; interactive mode emits `action_id` values for external Slack interactivity handlers ([#65](https://github.com/seqeralabs/nf-slack/issues/65))
+- **Seqera Platform action buttons**: View links to the Platform run page; Cancel links to the Platform API cancel endpoint; Resume/Relaunch reserved pending per-run API URLs ([#65](https://github.com/seqeralabs/nf-slack/issues/65))
 
 ## [0.5.1] - 2026-02-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Seqera Platform action buttons**: Contextual Cancel, Resume, and Relaunch buttons alongside View in Seqera Platform. Link mode (default) opens the Platform run page; interactive mode emits `action_id` values for external Slack interactivity handlers ([#65](https://github.com/seqeralabs/nf-slack/issues/65))
+
 ## [0.5.1] - 2026-02-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -87,4 +87,4 @@ See the [Examples Gallery](https://seqeralabs.github.io/nf-slack/latest/examples
 
 ## License
 
-Copyright 2025, Seqera Labs. Licensed under the Apache License, Version 2.0.
+Copyright 2025-2026, Seqera Labs. Licensed under the Apache License, Version 2.0.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -175,9 +175,21 @@ Configuration for workflow error notifications.
 
 ### `slack.seqeraPlatform`
 
-| Property  | Type      | Default | Description                                               |
-| --------- | --------- | ------- | --------------------------------------------------------- |
-| `enabled` | `Boolean` | `true`  | Enable Seqera Platform deep link buttons in notifications |
+| Property        | Type      | Default | Description                                             |
+| --------------- | --------- | ------- | ------------------------------------------------------- |
+| `enabled`       | `Boolean` | `true`  | Enable Seqera Platform action buttons in notifications  |
+| `actionButtons` | `Map`     | `{}`    | Cancel/Resume/Relaunch button configuration (see below) |
+
+#### `slack.seqeraPlatform.actionButtons`
+
+| Property   | Type      | Default  | Description                                                       |
+| ---------- | --------- | -------- | ----------------------------------------------------------------- |
+| `mode`     | `String`  | `'link'` | `'link'` for URL buttons, `'interactive'` for `action_id` buttons |
+| `cancel`   | `Boolean` | `true`   | Show Cancel on running/start/progress messages                    |
+| `resume`   | `Boolean` | `true`   | Show Resume on failure messages                                   |
+| `relaunch` | `Boolean` | `true`   | Show Relaunch on failure and completion messages                  |
+
+Interactive mode requires an external Slack interactivity endpoint that verifies the signing secret and calls Seqera Platform APIs. The plugin only emits button payloads.
 
 ---
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -182,14 +182,13 @@ Configuration for workflow error notifications.
 
 #### `slack.seqeraPlatform.actionButtons`
 
-| Property   | Type      | Default  | Description                                                       |
-| ---------- | --------- | -------- | ----------------------------------------------------------------- |
-| `mode`     | `String`  | `'link'` | `'link'` for URL buttons, `'interactive'` for `action_id` buttons |
-| `cancel`   | `Boolean` | `true`   | Show Cancel on running/start/progress messages                    |
-| `resume`   | `Boolean` | `true`   | Show Resume on failure messages                                   |
-| `relaunch` | `Boolean` | `true`   | Show Relaunch on failure and completion messages                  |
+| Property   | Type      | Default | Description                                                         |
+| ---------- | --------- | ------- | ------------------------------------------------------------------- |
+| `cancel`   | `Boolean` | `true`  | Show Cancel on running/start/progress messages (Platform API URL)   |
+| `resume`   | `Boolean` | `true`  | Reserved for future Resume button when a per-run URL is available   |
+| `relaunch` | `Boolean` | `true`  | Reserved for future Relaunch button when a per-run URL is available |
 
-Interactive mode requires an external Slack interactivity endpoint that verifies the signing secret and calls Seqera Platform APIs. The plugin only emits button payloads.
+Cancel links to `{tower.endpoint}/workflow/{runId}/cancel`. Resume and relaunch are not emitted until per-run API URLs are available.
 
 ---
 

--- a/docs/usage/guide.md
+++ b/docs/usage/guide.md
@@ -252,10 +252,9 @@ slack {
     seqeraPlatform {
         enabled = true
         actionButtons {
-            mode = 'link'      // default: URL buttons open the Platform run page
-            cancel = true      // show Cancel while running
-            resume = true      // show Resume on failure
-            relaunch = true    // show Relaunch on failure/completion
+            cancel = true      // links to POST /workflow/:id/cancel API path
+            resume = true      // reserved — no per-run URL yet
+            relaunch = true    // reserved — no per-run URL yet
         }
     }
 }
@@ -263,17 +262,15 @@ slack {
 
 ### Button behavior by workflow phase
 
-| Phase                    | Buttons                |
-| ------------------------ | ---------------------- |
-| Running (start/progress) | View, Cancel           |
-| Failed (error)           | View, Resume, Relaunch |
-| Completed                | View, Relaunch         |
+| Phase                    | Buttons      |
+| ------------------------ | ------------ |
+| Running (start/progress) | View, Cancel |
+| Failed (error)           | View         |
+| Completed                | View         |
 
-In **link mode** (default), Cancel/Resume/Relaunch open the same Platform run page where those actions are available in the UI. One-click API execution from Slack requires an external interactivity handler.
-
-### Interactive mode (advanced)
-
-Set `actionButtons.mode = 'interactive'` to emit Slack buttons with `action_id` values (`seqera_platform_view`, `seqera_platform_cancel`, `seqera_platform_resume`, `seqera_platform_relaunch`) and the workflow run ID in `value`. A separate HTTP endpoint (with Slack signing secret verification) must call Seqera Platform APIs — this cannot run inside the Nextflow plugin during `nextflow run`.
+- **View** opens the Platform run page (`watchUrl` from nf-tower).
+- **Cancel** links to `{tower.endpoint}/workflow/{runId}/cancel` ([Platform API](https://docs.seqera.io/platform-api/cancel-workflow)). The API endpoint is derived from `tower.endpoint` in your Nextflow config.
+- **Resume** and **Relaunch** are not shown yet — they require `POST /workflow/launch` with a prepared body rather than a per-run URL.
 
 ## Custom Messages from Code
 

--- a/docs/usage/guide.md
+++ b/docs/usage/guide.md
@@ -241,7 +241,7 @@ File paths are relative to the pipeline launch directory.
 
 ## Seqera Platform Integration
 
-If you run pipelines through [Seqera Platform](https://seqera.io/platform/), nf-slack can automatically add deep links to the Platform run page:
+If you run pipelines through [Seqera Platform](https://seqera.io/platform/), nf-slack can automatically add contextual action buttons to Slack notifications:
 
 ```groovy
 slack {
@@ -251,9 +251,29 @@ slack {
     }
     seqeraPlatform {
         enabled = true
+        actionButtons {
+            mode = 'link'      // default: URL buttons open the Platform run page
+            cancel = true      // show Cancel while running
+            resume = true      // show Resume on failure
+            relaunch = true    // show Relaunch on failure/completion
+        }
     }
 }
 ```
+
+### Button behavior by workflow phase
+
+| Phase                    | Buttons                |
+| ------------------------ | ---------------------- |
+| Running (start/progress) | View, Cancel           |
+| Failed (error)           | View, Resume, Relaunch |
+| Completed                | View, Relaunch         |
+
+In **link mode** (default), Cancel/Resume/Relaunch open the same Platform run page where those actions are available in the UI. One-click API execution from Slack requires an external interactivity handler.
+
+### Interactive mode (advanced)
+
+Set `actionButtons.mode = 'interactive'` to emit Slack buttons with `action_id` values (`seqera_platform_view`, `seqera_platform_cancel`, `seqera_platform_resume`, `seqera_platform_relaunch`) and the workflow run ID in `value`. A separate HTTP endpoint (with Slack signing secret verification) must call Seqera Platform APIs — this cannot run inside the Nextflow plugin during `nextflow run`.
 
 ## Custom Messages from Code
 

--- a/src/main/groovy/nextflow/slack/BotSlackSender.groovy
+++ b/src/main/groovy/nextflow/slack/BotSlackSender.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Seqera Labs
+ * Copyright 2025-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/slack/OnCompleteConfig.groovy
+++ b/src/main/groovy/nextflow/slack/OnCompleteConfig.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Seqera Labs
+ * Copyright 2025-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/slack/OnErrorConfig.groovy
+++ b/src/main/groovy/nextflow/slack/OnErrorConfig.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Seqera Labs
+ * Copyright 2025-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/slack/OnProgressConfig.groovy
+++ b/src/main/groovy/nextflow/slack/OnProgressConfig.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Seqera Labs
+ * Copyright 2025-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/slack/OnStartConfig.groovy
+++ b/src/main/groovy/nextflow/slack/OnStartConfig.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Seqera Labs
+ * Copyright 2025-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/slack/ReactionsConfig.groovy
+++ b/src/main/groovy/nextflow/slack/ReactionsConfig.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Seqera Labs
+ * Copyright 2025-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/slack/SeqeraMessagePhase.groovy
+++ b/src/main/groovy/nextflow/slack/SeqeraMessagePhase.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Seqera Labs
+ * Copyright 2025-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/slack/SeqeraMessagePhase.groovy
+++ b/src/main/groovy/nextflow/slack/SeqeraMessagePhase.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.slack
+
+import groovy.transform.CompileStatic
+
+/**
+ * Workflow phase used to select contextual Seqera Platform action buttons.
+ */
+@CompileStatic
+enum SeqeraMessagePhase {
+    RUNNING,
+    COMPLETED,
+    FAILED
+}

--- a/src/main/groovy/nextflow/slack/SeqeraPlatformActionButtonsConfig.groovy
+++ b/src/main/groovy/nextflow/slack/SeqeraPlatformActionButtonsConfig.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Seqera Labs
+ * Copyright 2025-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/slack/SeqeraPlatformActionButtonsConfig.groovy
+++ b/src/main/groovy/nextflow/slack/SeqeraPlatformActionButtonsConfig.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.slack
+
+import groovy.transform.CompileStatic
+
+/**
+ * Configuration for Seqera Platform action buttons in Slack messages.
+ *
+ * <p>Link mode (default) emits URL buttons that open the Platform run page.
+ * Interactive mode emits action_id buttons for an external Slack interactivity handler.
+ */
+@CompileStatic
+class SeqeraPlatformActionButtonsConfig {
+
+    static final String MODE_LINK = 'link'
+    static final String MODE_INTERACTIVE = 'interactive'
+
+    final String mode
+    final boolean cancel
+    final boolean resume
+    final boolean relaunch
+
+    SeqeraPlatformActionButtonsConfig(Map config) {
+        config = config ?: [:]
+        this.mode = (config.mode as String ?: MODE_LINK).toLowerCase()
+        this.cancel = config.cancel != null ? config.cancel as boolean : true
+        this.resume = config.resume != null ? config.resume as boolean : true
+        this.relaunch = config.relaunch != null ? config.relaunch as boolean : true
+    }
+
+    boolean isLinkMode() {
+        return mode == MODE_LINK
+    }
+
+    boolean isInteractiveMode() {
+        return mode == MODE_INTERACTIVE
+    }
+}

--- a/src/main/groovy/nextflow/slack/SeqeraPlatformActionButtonsConfig.groovy
+++ b/src/main/groovy/nextflow/slack/SeqeraPlatformActionButtonsConfig.groovy
@@ -17,44 +17,24 @@
 package nextflow.slack
 
 import groovy.transform.CompileStatic
-import groovy.util.logging.Slf4j
 
 /**
  * Configuration for Seqera Platform action buttons in Slack messages.
  *
- * <p>Link mode (default) emits URL buttons that open the Platform run page.
- * Interactive mode emits action_id buttons for an external Slack interactivity handler.
+ * <p>Buttons link to Platform UI and API endpoints. Resume and relaunch are reserved
+ * for when per-run API URLs become available.
  */
 @CompileStatic
-@Slf4j
 class SeqeraPlatformActionButtonsConfig {
 
-    static final String MODE_LINK = 'link'
-    static final String MODE_INTERACTIVE = 'interactive'
-
-    final String mode
     final boolean cancel
     final boolean resume
     final boolean relaunch
 
     SeqeraPlatformActionButtonsConfig(Map config) {
         config = config ?: [:]
-        def configuredMode = (config.mode as String ?: MODE_LINK).toLowerCase()
-        if (configuredMode != MODE_LINK && configuredMode != MODE_INTERACTIVE) {
-            log.warn "Slack plugin: Unknown seqeraPlatform.actionButtons.mode '${configuredMode}'; falling back to '${MODE_LINK}'"
-            configuredMode = MODE_LINK
-        }
-        this.mode = configuredMode
         this.cancel = config.cancel != null ? config.cancel as boolean : true
         this.resume = config.resume != null ? config.resume as boolean : true
         this.relaunch = config.relaunch != null ? config.relaunch as boolean : true
-    }
-
-    boolean isLinkMode() {
-        return mode == MODE_LINK
-    }
-
-    boolean isInteractiveMode() {
-        return mode == MODE_INTERACTIVE
     }
 }

--- a/src/main/groovy/nextflow/slack/SeqeraPlatformActionButtonsConfig.groovy
+++ b/src/main/groovy/nextflow/slack/SeqeraPlatformActionButtonsConfig.groovy
@@ -17,6 +17,7 @@
 package nextflow.slack
 
 import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
 
 /**
  * Configuration for Seqera Platform action buttons in Slack messages.
@@ -25,6 +26,7 @@ import groovy.transform.CompileStatic
  * Interactive mode emits action_id buttons for an external Slack interactivity handler.
  */
 @CompileStatic
+@Slf4j
 class SeqeraPlatformActionButtonsConfig {
 
     static final String MODE_LINK = 'link'
@@ -37,7 +39,12 @@ class SeqeraPlatformActionButtonsConfig {
 
     SeqeraPlatformActionButtonsConfig(Map config) {
         config = config ?: [:]
-        this.mode = (config.mode as String ?: MODE_LINK).toLowerCase()
+        def configuredMode = (config.mode as String ?: MODE_LINK).toLowerCase()
+        if (configuredMode != MODE_LINK && configuredMode != MODE_INTERACTIVE) {
+            log.warn "Slack plugin: Unknown seqeraPlatform.actionButtons.mode '${configuredMode}'; falling back to '${MODE_LINK}'"
+            configuredMode = MODE_LINK
+        }
+        this.mode = configuredMode
         this.cancel = config.cancel != null ? config.cancel as boolean : true
         this.resume = config.resume != null ? config.resume as boolean : true
         this.relaunch = config.relaunch != null ? config.relaunch as boolean : true

--- a/src/main/groovy/nextflow/slack/SeqeraPlatformConfig.groovy
+++ b/src/main/groovy/nextflow/slack/SeqeraPlatformConfig.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Seqera Labs
+ * Copyright 2025-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/slack/SeqeraPlatformConfig.groovy
+++ b/src/main/groovy/nextflow/slack/SeqeraPlatformConfig.groovy
@@ -22,8 +22,7 @@ import groovy.transform.CompileStatic
  * Configuration for Seqera Platform deep link integration.
  *
  * When Seqera Platform (Tower) is configured, adds contextual action buttons
- * to Slack notifications that link to the workflow run (or emit interactive
- * action IDs for external handlers).
+ * to Slack notifications that link to the workflow run page and Platform API paths.
  *
  * @author Adam Talbot <adam.talbot@seqera.io>
  */

--- a/src/main/groovy/nextflow/slack/SeqeraPlatformConfig.groovy
+++ b/src/main/groovy/nextflow/slack/SeqeraPlatformConfig.groovy
@@ -21,8 +21,9 @@ import groovy.transform.CompileStatic
 /**
  * Configuration for Seqera Platform deep link integration.
  *
- * When Seqera Platform (Tower) is configured, adds a "View in Seqera Platform"
- * button to Slack notifications that links directly to the workflow run.
+ * When Seqera Platform (Tower) is configured, adds contextual action buttons
+ * to Slack notifications that link to the workflow run (or emit interactive
+ * action IDs for external handlers).
  *
  * @author Adam Talbot <adam.talbot@seqera.io>
  */
@@ -34,7 +35,14 @@ class SeqeraPlatformConfig {
      */
     final boolean enabled
 
+    /**
+     * Action button configuration (View / Cancel / Resume / Relaunch)
+     */
+    final SeqeraPlatformActionButtonsConfig actionButtons
+
     SeqeraPlatformConfig(Map config) {
-        this.enabled = config?.enabled != null ? config.enabled as boolean : true
+        config = config ?: [:]
+        this.enabled = config.enabled != null ? config.enabled as boolean : true
+        this.actionButtons = new SeqeraPlatformActionButtonsConfig(config.actionButtons as Map)
     }
 }

--- a/src/main/groovy/nextflow/slack/SeqeraPlatformUrlBuilder.groovy
+++ b/src/main/groovy/nextflow/slack/SeqeraPlatformUrlBuilder.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.slack
+
+import groovy.transform.CompileStatic
+
+/**
+ * Helpers for parsing Seqera Platform watch URLs returned by TowerClient.
+ */
+@CompileStatic
+class SeqeraPlatformUrlBuilder {
+
+    /**
+     * Extract the workflow run ID from a Platform watch URL.
+     * Example: https://cloud.seqera.io/orgs/foo/workspaces/bar/watch/abc123 -> abc123
+     */
+    static String extractWorkflowRunId(String watchUrl) {
+        if (!watchUrl) return null
+        def marker = '/watch/'
+        def start = watchUrl.indexOf(marker)
+        if (start < 0) return null
+        def idPart = watchUrl.substring(start + marker.length())
+        def end = idPart.findIndexOf { it == '?' || it == '/' }
+        return end >= 0 ? idPart.substring(0, end) : idPart
+    }
+}

--- a/src/main/groovy/nextflow/slack/SeqeraPlatformUrlBuilder.groovy
+++ b/src/main/groovy/nextflow/slack/SeqeraPlatformUrlBuilder.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Seqera Labs
+ * Copyright 2025-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/slack/SeqeraPlatformUrlBuilder.groovy
+++ b/src/main/groovy/nextflow/slack/SeqeraPlatformUrlBuilder.groovy
@@ -19,10 +19,14 @@ package nextflow.slack
 import groovy.transform.CompileStatic
 
 /**
- * Helpers for parsing Seqera Platform watch URLs returned by TowerClient.
+ * Helpers for Seqera Platform watch URLs and workflow action API paths.
+ *
+ * @see <a href="https://docs.seqera.io/platform-api/cancel-workflow">Cancel workflow</a>
  */
 @CompileStatic
 class SeqeraPlatformUrlBuilder {
+
+    static final String DEFAULT_API_ENDPOINT = 'https://api.cloud.seqera.io'
 
     /**
      * Extract the workflow run ID from a Platform watch URL.
@@ -36,5 +40,21 @@ class SeqeraPlatformUrlBuilder {
         def idPart = watchUrl.substring(start + marker.length())
         def end = idPart.findIndexOf { it == '?' || it == '/' }
         return end >= 0 ? idPart.substring(0, end) : idPart
+    }
+
+    /**
+     * Normalize {@code tower.endpoint} to a base URL without a trailing slash.
+     */
+    static String normalizeApiEndpoint(String endpoint) {
+        def base = (endpoint ?: DEFAULT_API_ENDPOINT).trim()
+        return base.endsWith('/') ? base.substring(0, base.length() - 1) : base
+    }
+
+    /**
+     * URL for {@code POST /workflow/:workflowId/cancel}.
+     */
+    static String cancelWorkflowUrl(String apiEndpoint, String workflowRunId) {
+        if (!workflowRunId) return null
+        return "${normalizeApiEndpoint(apiEndpoint)}/workflow/${workflowRunId}/cancel"
     }
 }

--- a/src/main/groovy/nextflow/slack/SeqeraWatchContext.groovy
+++ b/src/main/groovy/nextflow/slack/SeqeraWatchContext.groovy
@@ -19,22 +19,28 @@ package nextflow.slack
 import groovy.transform.CompileStatic
 
 /**
- * Parsed Seqera Platform watch URL and workflow run identifier.
+ * Parsed Seqera Platform watch URL, workflow run identifier, and API base URL.
  */
 @CompileStatic
 class SeqeraWatchContext {
 
     final String watchUrl
     final String workflowRunId
+    final String apiEndpoint
 
-    SeqeraWatchContext(String watchUrl, String workflowRunId) {
+    SeqeraWatchContext(String watchUrl, String workflowRunId, String apiEndpoint) {
         this.watchUrl = watchUrl
         this.workflowRunId = workflowRunId
+        this.apiEndpoint = apiEndpoint
     }
 
-    static SeqeraWatchContext fromWatchUrl(String watchUrl) {
+    static SeqeraWatchContext fromWatchUrl(String watchUrl, String apiEndpoint = null) {
         if (!watchUrl) return null
         def workflowRunId = SeqeraPlatformUrlBuilder.extractWorkflowRunId(watchUrl)
-        return new SeqeraWatchContext(watchUrl, workflowRunId)
+        return new SeqeraWatchContext(
+            watchUrl,
+            workflowRunId,
+            SeqeraPlatformUrlBuilder.normalizeApiEndpoint(apiEndpoint)
+        )
     }
 }

--- a/src/main/groovy/nextflow/slack/SeqeraWatchContext.groovy
+++ b/src/main/groovy/nextflow/slack/SeqeraWatchContext.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.slack
+
+import groovy.transform.CompileStatic
+
+/**
+ * Parsed Seqera Platform watch URL and workflow run identifier.
+ */
+@CompileStatic
+class SeqeraWatchContext {
+
+    final String watchUrl
+    final String workflowRunId
+
+    SeqeraWatchContext(String watchUrl, String workflowRunId) {
+        this.watchUrl = watchUrl
+        this.workflowRunId = workflowRunId
+    }
+
+    static SeqeraWatchContext fromWatchUrl(String watchUrl) {
+        if (!watchUrl) return null
+        def workflowRunId = SeqeraPlatformUrlBuilder.extractWorkflowRunId(watchUrl)
+        return new SeqeraWatchContext(watchUrl, workflowRunId)
+    }
+}

--- a/src/main/groovy/nextflow/slack/SeqeraWatchContext.groovy
+++ b/src/main/groovy/nextflow/slack/SeqeraWatchContext.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Seqera Labs
+ * Copyright 2025-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/slack/SlackConfig.groovy
+++ b/src/main/groovy/nextflow/slack/SlackConfig.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Seqera Labs
+ * Copyright 2025-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/slack/SlackExtension.groovy
+++ b/src/main/groovy/nextflow/slack/SlackExtension.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Seqera Labs
+ * Copyright 2025-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/slack/SlackFactory.groovy
+++ b/src/main/groovy/nextflow/slack/SlackFactory.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Seqera Labs
+ * Copyright 2025-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/slack/SlackMessageBuilder.groovy
+++ b/src/main/groovy/nextflow/slack/SlackMessageBuilder.groovy
@@ -620,6 +620,7 @@ class SlackMessageBuilder {
             case 'failed':
                 return SeqeraMessagePhase.FAILED
             default:
+                // Custom statuses (e.g. paused) are treated as RUNNING for button selection.
                 return SeqeraMessagePhase.RUNNING
         }
     }

--- a/src/main/groovy/nextflow/slack/SlackMessageBuilder.groovy
+++ b/src/main/groovy/nextflow/slack/SlackMessageBuilder.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Seqera Labs
+ * Copyright 2025-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/slack/SlackMessageBuilder.groovy
+++ b/src/main/groovy/nextflow/slack/SlackMessageBuilder.groovy
@@ -116,24 +116,111 @@ class SlackMessageBuilder {
     }
 
     /**
-     * Create a Seqera Platform button action block
+     * Append contextual Seqera Platform action buttons when a watch URL is available.
      */
-    private static Map createSeqeraPlatformButton(String url) {
-        return [
-            type: 'actions',
-            elements: [
-                [
-                    type: 'button',
-                    text: [
-                        type: 'plain_text',
-                        text: '🔗 View in Seqera Platform',
-                        emoji: true
-                    ],
-                    url: url,
-                    style: 'primary'
-                ]
-            ]
-        ]
+    private void appendSeqeraPlatformActions(List blocks, SeqeraMessagePhase phase) {
+        def context = getSeqeraWatchContext()
+        if (!context) return
+
+        def actions = createSeqeraPlatformActions(context, phase)
+        if (actions) {
+            blocks << actions
+        }
+    }
+
+    /**
+     * Build Seqera Platform action block for the given workflow phase.
+     * Package-private for unit tests.
+     */
+    Map createSeqeraPlatformActions(SeqeraWatchContext context, SeqeraMessagePhase phase) {
+        def buttonConfig = config.seqeraPlatform?.actionButtons
+        if (!buttonConfig) return null
+
+        def elements = [] as List<Map>
+        elements << createViewButton(context, buttonConfig)
+
+        switch (phase) {
+            case SeqeraMessagePhase.RUNNING:
+                if (buttonConfig.cancel) {
+                    elements << createCancelButton(context, buttonConfig)
+                }
+                break
+            case SeqeraMessagePhase.FAILED:
+                if (buttonConfig.resume) {
+                    elements << createResumeButton(context, buttonConfig)
+                }
+                if (buttonConfig.relaunch) {
+                    elements << createRelaunchButton(context, buttonConfig)
+                }
+                break
+            case SeqeraMessagePhase.COMPLETED:
+                if (buttonConfig.relaunch) {
+                    elements << createRelaunchButton(context, buttonConfig)
+                }
+                break
+        }
+
+        return elements ? [type: 'actions', elements: elements] : null
+    }
+
+    private SeqeraWatchContext getSeqeraWatchContext() {
+        if (!config.seqeraPlatform?.enabled) return null
+        def watchUrl = getTowerClientWatchUrl()
+        log.debug "Seqera Platform: watchUrl=${watchUrl}"
+        return SeqeraWatchContext.fromWatchUrl(watchUrl)
+    }
+
+    private static Map createViewButton(SeqeraWatchContext context, SeqeraPlatformActionButtonsConfig buttonConfig) {
+        if (buttonConfig.isLinkMode()) {
+            return createLinkButton('🔗 View in Seqera Platform', context.watchUrl, 'primary')
+        }
+        return createInteractiveButton('🔗 View in Seqera Platform', 'seqera_platform_view', context.workflowRunId)
+    }
+
+    private static Map createCancelButton(SeqeraWatchContext context, SeqeraPlatformActionButtonsConfig buttonConfig) {
+        if (buttonConfig.isLinkMode()) {
+            return createLinkButton('⏹ Cancel', context.watchUrl, 'danger')
+        }
+        return createInteractiveButton('⏹ Cancel', 'seqera_platform_cancel', context.workflowRunId, 'danger')
+    }
+
+    private static Map createResumeButton(SeqeraWatchContext context, SeqeraPlatformActionButtonsConfig buttonConfig) {
+        if (buttonConfig.isLinkMode()) {
+            return createLinkButton('▶️ Resume', context.watchUrl)
+        }
+        return createInteractiveButton('▶️ Resume', 'seqera_platform_resume', context.workflowRunId)
+    }
+
+    private static Map createRelaunchButton(SeqeraWatchContext context, SeqeraPlatformActionButtonsConfig buttonConfig) {
+        if (buttonConfig.isLinkMode()) {
+            return createLinkButton('🔄 Relaunch', context.watchUrl)
+        }
+        return createInteractiveButton('🔄 Relaunch', 'seqera_platform_relaunch', context.workflowRunId)
+    }
+
+    private static Map createLinkButton(String label, String url, String style = null) {
+        def button = [
+            type: 'button',
+            text: [type: 'plain_text', text: label, emoji: true],
+            url: url
+        ] as Map
+        if (style) {
+            button.style = style
+        }
+        return button
+    }
+
+    private static Map createInteractiveButton(String label, String actionId, String value, String style = null) {
+        def button = [
+            type: 'button',
+            text: [type: 'plain_text', text: label, emoji: true],
+            action_id: actionId,
+            value: value ?: ''
+        ] as Map
+        if (style) {
+            button.style = style
+        }
+        return button
     }
 
     /**
@@ -147,21 +234,6 @@ class SlackMessageBuilder {
                 text: "*Command Line*\n```${commandLine}```"
             ]
         ]
-    }
-
-    /**
-     * Get Seqera Platform watch URL from TowerClient if deep links are enabled.
-     * Returns null if unavailable — callers should skip the button.
-     *
-     * The URL is read directly from TowerClient's watchUrl field, which is the
-     * fully-resolved URL returned by the Seqera Platform API.
-     */
-    private String getSeqeraPlatformUrl() {
-        if (!config.seqeraPlatform?.enabled) return null
-
-        def watchUrl = getTowerClientWatchUrl()
-        log.debug "Seqera Platform: watchUrl=${watchUrl}"
-        return watchUrl
     }
 
     /**
@@ -272,11 +344,7 @@ class SlackMessageBuilder {
             blocks << createContextFooter('started', timestamp, workflowName)
         }
 
-        // Seqera Platform deep link button
-        def seqeraUrl = getSeqeraPlatformUrl()
-        if (seqeraUrl) {
-            blocks << createSeqeraPlatformButton(seqeraUrl)
-        }
+        appendSeqeraPlatformActions(blocks, SeqeraMessagePhase.RUNNING)
 
         return createMessagePayload(blocks, threadTs)
     }
@@ -333,11 +401,7 @@ class SlackMessageBuilder {
             blocks << createContextFooter('completed', timestamp, workflowName)
         }
 
-        // Seqera Platform deep link button
-        def seqeraUrl = getSeqeraPlatformUrl()
-        if (seqeraUrl) {
-            blocks << createSeqeraPlatformButton(seqeraUrl)
-        }
+        appendSeqeraPlatformActions(blocks, SeqeraMessagePhase.COMPLETED)
 
         return createMessagePayload(blocks, threadTs)
     }
@@ -409,11 +473,7 @@ class SlackMessageBuilder {
             blocks << createContextFooter('failed', timestamp, workflowName)
         }
 
-        // Seqera Platform deep link button
-        def seqeraUrl = getSeqeraPlatformUrl()
-        if (seqeraUrl) {
-            blocks << createSeqeraPlatformButton(seqeraUrl)
-        }
+        appendSeqeraPlatformActions(blocks, SeqeraMessagePhase.FAILED)
 
         return createMessagePayload(blocks, threadTs)
     }
@@ -546,7 +606,22 @@ class SlackMessageBuilder {
             blocks << createContextFooter(status, timestamp, workflowName)
         }
 
+        appendSeqeraPlatformActions(blocks, seqeraPhaseForStatus(status))
+
         return createMessagePayload(blocks, threadTs)
+    }
+
+    private static SeqeraMessagePhase seqeraPhaseForStatus(String status) {
+        switch (status) {
+            case 'started':
+                return SeqeraMessagePhase.RUNNING
+            case 'completed':
+                return SeqeraMessagePhase.COMPLETED
+            case 'failed':
+                return SeqeraMessagePhase.FAILED
+            default:
+                return SeqeraMessagePhase.RUNNING
+        }
     }
 
     /**
@@ -630,6 +705,8 @@ class SlackMessageBuilder {
         }
         fields.add(createMarkdownField('Elapsed', elapsed))
         blocks.add(createFieldsSection(fields))
+
+        appendSeqeraPlatformActions(blocks, SeqeraMessagePhase.RUNNING)
 
         return createMessagePayload(blocks, threadTs)
     }

--- a/src/main/groovy/nextflow/slack/SlackMessageBuilder.groovy
+++ b/src/main/groovy/nextflow/slack/SlackMessageBuilder.groovy
@@ -137,26 +137,23 @@ class SlackMessageBuilder {
         if (!buttonConfig) return null
 
         def elements = [] as List<Map>
-        elements << createViewButton(context, buttonConfig)
+        elements << createLinkButton('🔗 View in Seqera Platform', context.watchUrl, 'primary')
 
         switch (phase) {
             case SeqeraMessagePhase.RUNNING:
                 if (buttonConfig.cancel) {
-                    elements << createCancelButton(context, buttonConfig)
+                    def cancelUrl = SeqeraPlatformUrlBuilder.cancelWorkflowUrl(
+                        context.apiEndpoint, context.workflowRunId)
+                    if (cancelUrl) {
+                        elements << createLinkButton('⏹ Cancel', cancelUrl, 'danger')
+                    }
                 }
                 break
             case SeqeraMessagePhase.FAILED:
-                if (buttonConfig.resume) {
-                    elements << createResumeButton(context, buttonConfig)
-                }
-                if (buttonConfig.relaunch) {
-                    elements << createRelaunchButton(context, buttonConfig)
-                }
+                // Resume requires POST /workflow/launch with a prepared body — no per-run URL yet.
                 break
             case SeqeraMessagePhase.COMPLETED:
-                if (buttonConfig.relaunch) {
-                    elements << createRelaunchButton(context, buttonConfig)
-                }
+                // Relaunch requires POST /workflow/launch — no per-run URL yet.
                 break
         }
 
@@ -167,35 +164,8 @@ class SlackMessageBuilder {
         if (!config.seqeraPlatform?.enabled) return null
         def watchUrl = getTowerClientWatchUrl()
         log.debug "Seqera Platform: watchUrl=${watchUrl}"
-        return SeqeraWatchContext.fromWatchUrl(watchUrl)
-    }
-
-    private static Map createViewButton(SeqeraWatchContext context, SeqeraPlatformActionButtonsConfig buttonConfig) {
-        if (buttonConfig.isLinkMode()) {
-            return createLinkButton('🔗 View in Seqera Platform', context.watchUrl, 'primary')
-        }
-        return createInteractiveButton('🔗 View in Seqera Platform', 'seqera_platform_view', context.workflowRunId)
-    }
-
-    private static Map createCancelButton(SeqeraWatchContext context, SeqeraPlatformActionButtonsConfig buttonConfig) {
-        if (buttonConfig.isLinkMode()) {
-            return createLinkButton('⏹ Cancel', context.watchUrl, 'danger')
-        }
-        return createInteractiveButton('⏹ Cancel', 'seqera_platform_cancel', context.workflowRunId, 'danger')
-    }
-
-    private static Map createResumeButton(SeqeraWatchContext context, SeqeraPlatformActionButtonsConfig buttonConfig) {
-        if (buttonConfig.isLinkMode()) {
-            return createLinkButton('▶️ Resume', context.watchUrl)
-        }
-        return createInteractiveButton('▶️ Resume', 'seqera_platform_resume', context.workflowRunId)
-    }
-
-    private static Map createRelaunchButton(SeqeraWatchContext context, SeqeraPlatformActionButtonsConfig buttonConfig) {
-        if (buttonConfig.isLinkMode()) {
-            return createLinkButton('🔄 Relaunch', context.watchUrl)
-        }
-        return createInteractiveButton('🔄 Relaunch', 'seqera_platform_relaunch', context.workflowRunId)
+        def apiEndpoint = session.config?.navigate('tower.endpoint') as String
+        return SeqeraWatchContext.fromWatchUrl(watchUrl, apiEndpoint)
     }
 
     private static Map createLinkButton(String label, String url, String style = null) {
@@ -203,19 +173,6 @@ class SlackMessageBuilder {
             type: 'button',
             text: [type: 'plain_text', text: label, emoji: true],
             url: url
-        ] as Map
-        if (style) {
-            button.style = style
-        }
-        return button
-    }
-
-    private static Map createInteractiveButton(String label, String actionId, String value, String style = null) {
-        def button = [
-            type: 'button',
-            text: [type: 'plain_text', text: label, emoji: true],
-            action_id: actionId,
-            value: value ?: ''
         ] as Map
         if (style) {
             button.style = style

--- a/src/main/groovy/nextflow/slack/SlackObserver.groovy
+++ b/src/main/groovy/nextflow/slack/SlackObserver.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Seqera Labs
+ * Copyright 2025-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/slack/SlackPlugin.groovy
+++ b/src/main/groovy/nextflow/slack/SlackPlugin.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Seqera Labs
+ * Copyright 2025-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/slack/SlackSender.groovy
+++ b/src/main/groovy/nextflow/slack/SlackSender.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Seqera Labs
+ * Copyright 2025-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/nextflow/slack/WebhookSlackSender.groovy
+++ b/src/main/groovy/nextflow/slack/WebhookSlackSender.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Seqera Labs
+ * Copyright 2025-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/slack/BotSlackSenderTest.groovy
+++ b/src/test/groovy/nextflow/slack/BotSlackSenderTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Seqera Labs
+ * Copyright 2025-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/slack/OnProgressConfigTest.groovy
+++ b/src/test/groovy/nextflow/slack/OnProgressConfigTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025, Seqera Labs
+ * Copyright 2024-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/slack/ReactionsConfigTest.groovy
+++ b/src/test/groovy/nextflow/slack/ReactionsConfigTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, Seqera Labs
+ * Copyright 2024-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/slack/SeqeraPlatformActionButtonsTest.groovy
+++ b/src/test/groovy/nextflow/slack/SeqeraPlatformActionButtonsTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Seqera Labs
+ * Copyright 2025-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/slack/SeqeraPlatformActionButtonsTest.groovy
+++ b/src/test/groovy/nextflow/slack/SeqeraPlatformActionButtonsTest.groovy
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.slack
+
+import nextflow.Session
+import nextflow.script.WorkflowMetadata
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class SeqeraPlatformActionButtonsTest extends Specification {
+
+    private static final String WATCH_URL = 'https://cloud.seqera.io/orgs/myorg/workspaces/myws/watch/abc123'
+
+    private SlackMessageBuilder createBuilder(Map seqeraConfig = [:]) {
+        def platformConfig = new SlackConfig([
+            webhook: 'https://hooks.slack.com/test',
+            seqeraPlatform: [enabled: true] + seqeraConfig
+        ])
+        def mockMetadata = Mock(WorkflowMetadata)
+        mockMetadata.scriptName >> 'test-workflow.nf'
+        def towerSession = Mock(Session)
+        towerSession.config >> [:]
+        towerSession.workflowMetadata >> mockMetadata
+        towerSession.runName >> 'crazy_einstein'
+        towerSession.uniqueId >> UUID.fromString('00000000-0000-0000-0000-000000000000')
+        def builder = Spy(new SlackMessageBuilder(platformConfig, towerSession))
+        builder.getTowerClientWatchUrl() >> WATCH_URL
+        return builder
+    }
+
+    def 'extractWorkflowRunId parses watch URL'() {
+        expect:
+        SeqeraPlatformUrlBuilder.extractWorkflowRunId(WATCH_URL) == 'abc123'
+        SeqeraPlatformUrlBuilder.extractWorkflowRunId('https://example.com/watch/run-id?tab=logs') == 'run-id'
+        SeqeraPlatformUrlBuilder.extractWorkflowRunId(null) == null
+        SeqeraPlatformUrlBuilder.extractWorkflowRunId('https://example.com/runs') == null
+    }
+
+    @Unroll
+    def 'link mode buttons for phase #phase'() {
+        given:
+        def builder = createBuilder()
+        def context = SeqeraWatchContext.fromWatchUrl(WATCH_URL)
+
+        when:
+        def actions = builder.createSeqeraPlatformActions(context, phase)
+
+        then:
+        actions.type == 'actions'
+        actions.elements*.text.text == labels
+        actions.elements.every { it.url == WATCH_URL }
+
+        where:
+        phase                        | labels
+        SeqeraMessagePhase.RUNNING   | ['🔗 View in Seqera Platform', '⏹ Cancel']
+        SeqeraMessagePhase.FAILED    | ['🔗 View in Seqera Platform', '▶️ Resume', '🔄 Relaunch']
+        SeqeraMessagePhase.COMPLETED | ['🔗 View in Seqera Platform', '🔄 Relaunch']
+    }
+
+    def 'interactive mode emits action_id buttons'() {
+        given:
+        def builder = createBuilder(actionButtons: [mode: 'interactive'])
+        def context = SeqeraWatchContext.fromWatchUrl(WATCH_URL)
+
+        when:
+        def actions = builder.createSeqeraPlatformActions(context, SeqeraMessagePhase.FAILED)
+
+        then:
+        actions.elements*.action_id == [
+            'seqera_platform_view',
+            'seqera_platform_resume',
+            'seqera_platform_relaunch'
+        ]
+        actions.elements*.value == ['abc123', 'abc123', 'abc123']
+        actions.elements.every { !it.url }
+    }
+
+    def 'disabled action buttons are omitted'() {
+        given:
+        def builder = createBuilder(actionButtons: [cancel: false, resume: false, relaunch: false])
+        def context = SeqeraWatchContext.fromWatchUrl(WATCH_URL)
+
+        when:
+        def running = builder.createSeqeraPlatformActions(context, SeqeraMessagePhase.RUNNING)
+        def failed = builder.createSeqeraPlatformActions(context, SeqeraMessagePhase.FAILED)
+        def completed = builder.createSeqeraPlatformActions(context, SeqeraMessagePhase.COMPLETED)
+
+        then:
+        running.elements*.text.text == ['🔗 View in Seqera Platform']
+        failed.elements*.text.text == ['🔗 View in Seqera Platform']
+        completed.elements*.text.text == ['🔗 View in Seqera Platform']
+    }
+
+    def 'actionButtons config defaults'() {
+        when:
+        def config = new SeqeraPlatformActionButtonsConfig([:])
+
+        then:
+        config.mode == 'link'
+        config.cancel
+        config.resume
+        config.relaunch
+        config.isLinkMode()
+        !config.isInteractiveMode()
+    }
+}

--- a/src/test/groovy/nextflow/slack/SeqeraPlatformActionButtonsTest.groovy
+++ b/src/test/groovy/nextflow/slack/SeqeraPlatformActionButtonsTest.groovy
@@ -24,6 +24,7 @@ import spock.lang.Unroll
 class SeqeraPlatformActionButtonsTest extends Specification {
 
     private static final String WATCH_URL = 'https://cloud.seqera.io/orgs/myorg/workspaces/myws/watch/abc123'
+    private static final String API_ENDPOINT = 'https://api.cloud.seqera.io'
 
     private SlackMessageBuilder createBuilder(Map seqeraConfig = [:]) {
         def platformConfig = new SlackConfig([
@@ -33,13 +34,17 @@ class SeqeraPlatformActionButtonsTest extends Specification {
         def mockMetadata = Mock(WorkflowMetadata)
         mockMetadata.scriptName >> 'test-workflow.nf'
         def towerSession = Mock(Session)
-        towerSession.config >> [:]
+        towerSession.config >> [tower: [endpoint: API_ENDPOINT]]
         towerSession.workflowMetadata >> mockMetadata
         towerSession.runName >> 'crazy_einstein'
         towerSession.uniqueId >> UUID.fromString('00000000-0000-0000-0000-000000000000')
         def builder = Spy(new SlackMessageBuilder(platformConfig, towerSession))
         builder.getTowerClientWatchUrl() >> WATCH_URL
         return builder
+    }
+
+    private static SeqeraWatchContext watchContext() {
+        return SeqeraWatchContext.fromWatchUrl(WATCH_URL, API_ENDPOINT)
     }
 
     def 'extractWorkflowRunId parses watch URL'() {
@@ -50,11 +55,20 @@ class SeqeraPlatformActionButtonsTest extends Specification {
         SeqeraPlatformUrlBuilder.extractWorkflowRunId('https://example.com/runs') == null
     }
 
+    def 'cancelWorkflowUrl builds Platform API path'() {
+        expect:
+        SeqeraPlatformUrlBuilder.cancelWorkflowUrl(API_ENDPOINT, 'abc123') ==
+            'https://api.cloud.seqera.io/workflow/abc123/cancel'
+        SeqeraPlatformUrlBuilder.cancelWorkflowUrl('https://api.cloud.seqera.io/', 'abc123') ==
+            'https://api.cloud.seqera.io/workflow/abc123/cancel'
+        SeqeraPlatformUrlBuilder.cancelWorkflowUrl(API_ENDPOINT, null) == null
+    }
+
     @Unroll
-    def 'link mode buttons for phase #phase'() {
+    def 'action buttons for phase #phase'() {
         given:
         def builder = createBuilder()
-        def context = SeqeraWatchContext.fromWatchUrl(WATCH_URL)
+        def context = watchContext()
 
         when:
         def actions = builder.createSeqeraPlatformActions(context, phase)
@@ -62,47 +76,26 @@ class SeqeraPlatformActionButtonsTest extends Specification {
         then:
         actions.type == 'actions'
         actions.elements*.text.text == labels
-        actions.elements.every { it.url == WATCH_URL }
+        actions.elements*.url == urls
 
         where:
-        phase                        | labels
-        SeqeraMessagePhase.RUNNING   | ['🔗 View in Seqera Platform', '⏹ Cancel']
-        SeqeraMessagePhase.FAILED    | ['🔗 View in Seqera Platform', '▶️ Resume', '🔄 Relaunch']
-        SeqeraMessagePhase.COMPLETED | ['🔗 View in Seqera Platform', '🔄 Relaunch']
+        phase                        | labels                                              | urls
+        SeqeraMessagePhase.RUNNING   | ['🔗 View in Seqera Platform', '⏹ Cancel']          | [WATCH_URL, 'https://api.cloud.seqera.io/workflow/abc123/cancel']
+        SeqeraMessagePhase.FAILED    | ['🔗 View in Seqera Platform']                      | [WATCH_URL]
+        SeqeraMessagePhase.COMPLETED | ['🔗 View in Seqera Platform']                      | [WATCH_URL]
     }
 
-    def 'interactive mode emits action_id buttons'() {
+    def 'cancel button omitted when disabled'() {
         given:
-        def builder = createBuilder(actionButtons: [mode: 'interactive'])
-        def context = SeqeraWatchContext.fromWatchUrl(WATCH_URL)
+        def builder = createBuilder(actionButtons: [cancel: false])
+        def context = watchContext()
 
         when:
-        def actions = builder.createSeqeraPlatformActions(context, SeqeraMessagePhase.FAILED)
+        def actions = builder.createSeqeraPlatformActions(context, SeqeraMessagePhase.RUNNING)
 
         then:
-        actions.elements*.action_id == [
-            'seqera_platform_view',
-            'seqera_platform_resume',
-            'seqera_platform_relaunch'
-        ]
-        actions.elements*.value == ['abc123', 'abc123', 'abc123']
-        actions.elements.every { !it.url }
-    }
-
-    def 'disabled action buttons are omitted'() {
-        given:
-        def builder = createBuilder(actionButtons: [cancel: false, resume: false, relaunch: false])
-        def context = SeqeraWatchContext.fromWatchUrl(WATCH_URL)
-
-        when:
-        def running = builder.createSeqeraPlatformActions(context, SeqeraMessagePhase.RUNNING)
-        def failed = builder.createSeqeraPlatformActions(context, SeqeraMessagePhase.FAILED)
-        def completed = builder.createSeqeraPlatformActions(context, SeqeraMessagePhase.COMPLETED)
-
-        then:
-        running.elements*.text.text == ['🔗 View in Seqera Platform']
-        failed.elements*.text.text == ['🔗 View in Seqera Platform']
-        completed.elements*.text.text == ['🔗 View in Seqera Platform']
+        actions.elements*.text.text == ['🔗 View in Seqera Platform']
+        actions.elements*.url == [WATCH_URL]
     }
 
     def 'actionButtons config defaults'() {
@@ -110,21 +103,8 @@ class SeqeraPlatformActionButtonsTest extends Specification {
         def config = new SeqeraPlatformActionButtonsConfig([:])
 
         then:
-        config.mode == 'link'
         config.cancel
         config.resume
         config.relaunch
-        config.isLinkMode()
-        !config.isInteractiveMode()
-    }
-
-    def 'should fall back to link mode for unknown mode values'() {
-        when:
-        def config = new SeqeraPlatformActionButtonsConfig([mode: 'url'])
-
-        then:
-        config.mode == 'link'
-        config.isLinkMode()
-        !config.isInteractiveMode()
     }
 }

--- a/src/test/groovy/nextflow/slack/SeqeraPlatformActionButtonsTest.groovy
+++ b/src/test/groovy/nextflow/slack/SeqeraPlatformActionButtonsTest.groovy
@@ -117,4 +117,14 @@ class SeqeraPlatformActionButtonsTest extends Specification {
         config.isLinkMode()
         !config.isInteractiveMode()
     }
+
+    def 'should fall back to link mode for unknown mode values'() {
+        when:
+        def config = new SeqeraPlatformActionButtonsConfig([mode: 'url'])
+
+        then:
+        config.mode == 'link'
+        config.isLinkMode()
+        !config.isInteractiveMode()
+    }
 }

--- a/src/test/groovy/nextflow/slack/SlackClientTest.groovy
+++ b/src/test/groovy/nextflow/slack/SlackClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Seqera Labs
+ * Copyright 2025-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/slack/SlackConfigTest.groovy
+++ b/src/test/groovy/nextflow/slack/SlackConfigTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Seqera Labs
+ * Copyright 2025-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/slack/SlackConfigTest.groovy
+++ b/src/test/groovy/nextflow/slack/SlackConfigTest.groovy
@@ -497,4 +497,32 @@ class SlackConfigTest extends Specification {
         config.seqeraPlatform != null
         config.seqeraPlatform.enabled == false
     }
+
+    def 'should parse seqeraPlatform actionButtons config'() {
+        given:
+        def session = Mock(Session) {
+            config >> [slack: [
+                webhook: [url: 'https://hooks.slack.com/test'],
+                seqeraPlatform: [
+                    enabled: true,
+                    actionButtons: [
+                        mode: 'interactive',
+                        cancel: false,
+                        resume: true,
+                        relaunch: false
+                    ]
+                ]
+            ]]
+        }
+
+        when:
+        def config = SlackConfig.from(session)
+
+        then:
+        config.seqeraPlatform.actionButtons.mode == 'interactive'
+        !config.seqeraPlatform.actionButtons.cancel
+        config.seqeraPlatform.actionButtons.resume
+        !config.seqeraPlatform.actionButtons.relaunch
+        config.seqeraPlatform.actionButtons.isInteractiveMode()
+    }
 }

--- a/src/test/groovy/nextflow/slack/SlackConfigTest.groovy
+++ b/src/test/groovy/nextflow/slack/SlackConfigTest.groovy
@@ -506,7 +506,6 @@ class SlackConfigTest extends Specification {
                 seqeraPlatform: [
                     enabled: true,
                     actionButtons: [
-                        mode: 'interactive',
                         cancel: false,
                         resume: true,
                         relaunch: false
@@ -519,10 +518,8 @@ class SlackConfigTest extends Specification {
         def config = SlackConfig.from(session)
 
         then:
-        config.seqeraPlatform.actionButtons.mode == 'interactive'
         !config.seqeraPlatform.actionButtons.cancel
         config.seqeraPlatform.actionButtons.resume
         !config.seqeraPlatform.actionButtons.relaunch
-        config.seqeraPlatform.actionButtons.isInteractiveMode()
     }
 }

--- a/src/test/groovy/nextflow/slack/SlackExtensionTest.groovy
+++ b/src/test/groovy/nextflow/slack/SlackExtensionTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Seqera Labs
+ * Copyright 2025-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/slack/SlackMessageBuilderTest.groovy
+++ b/src/test/groovy/nextflow/slack/SlackMessageBuilderTest.groovy
@@ -622,7 +622,7 @@ class SlackMessageBuilderTest extends Specification {
         text.contains('5')
     }
 
-    def 'should include Seqera Platform button when watchUrl is available'() {
+    def 'should include Seqera Platform buttons when watchUrl is available'() {
         given:
         def platformConfig = new SlackConfig([
             webhook: 'https://hooks.slack.com/test',
@@ -645,8 +645,37 @@ class SlackMessageBuilderTest extends Specification {
         then:
         def actionsBlock = json.blocks.find { it.type == 'actions' }
         actionsBlock != null
-        actionsBlock.elements[0].type == 'button'
+        actionsBlock.elements*.type == ['button', 'button']
         actionsBlock.elements[0].url == 'https://cloud.seqera.io/orgs/myorg/workspaces/myws/watch/abc123'
+        actionsBlock.elements[0].text.text == '🔗 View in Seqera Platform'
+        actionsBlock.elements[1].text.text == '⏹ Cancel'
+    }
+
+    def 'should include Resume and Relaunch buttons on workflow error'() {
+        given:
+        def platformConfig = new SlackConfig([
+            webhook: 'https://hooks.slack.com/test',
+            seqeraPlatform: [enabled: true]
+        ])
+        def mockMetadata = Mock(WorkflowMetadata)
+        mockMetadata.scriptName >> 'test-workflow.nf'
+        mockMetadata.duration >> nextflow.util.Duration.of('1m')
+        mockMetadata.errorMessage >> 'boom'
+        def towerSession = Mock(Session)
+        towerSession.config >> [:]
+        towerSession.workflowMetadata >> mockMetadata
+        towerSession.runName >> 'crazy_einstein'
+        towerSession.uniqueId >> UUID.fromString('00000000-0000-0000-0000-000000000000')
+        def builder = Spy(new SlackMessageBuilder(platformConfig, towerSession))
+        builder.getTowerClientWatchUrl() >> 'https://cloud.seqera.io/orgs/myorg/workspaces/myws/watch/abc123'
+
+        when:
+        def message = builder.buildWorkflowErrorMessage(null)
+        def json = new JsonSlurper().parseText(message)
+
+        then:
+        def actionsBlock = json.blocks.find { it.type == 'actions' }
+        actionsBlock.elements*.text.text == ['🔗 View in Seqera Platform', '▶️ Resume', '🔄 Relaunch']
     }
 
     def 'should not include Seqera Platform button when no TowerClient present'() {

--- a/src/test/groovy/nextflow/slack/SlackMessageBuilderTest.groovy
+++ b/src/test/groovy/nextflow/slack/SlackMessageBuilderTest.groovy
@@ -631,7 +631,7 @@ class SlackMessageBuilderTest extends Specification {
         def mockMetadata = Mock(WorkflowMetadata)
         mockMetadata.scriptName >> 'test-workflow.nf'
         def towerSession = Mock(Session)
-        towerSession.config >> [:]
+        towerSession.config >> [tower: [endpoint: 'https://api.cloud.seqera.io']]
         towerSession.workflowMetadata >> mockMetadata
         towerSession.runName >> 'crazy_einstein'
         towerSession.uniqueId >> UUID.fromString('00000000-0000-0000-0000-000000000000')
@@ -649,9 +649,10 @@ class SlackMessageBuilderTest extends Specification {
         actionsBlock.elements[0].url == 'https://cloud.seqera.io/orgs/myorg/workspaces/myws/watch/abc123'
         actionsBlock.elements[0].text.text == '🔗 View in Seqera Platform'
         actionsBlock.elements[1].text.text == '⏹ Cancel'
+        actionsBlock.elements[1].url == 'https://api.cloud.seqera.io/workflow/abc123/cancel'
     }
 
-    def 'should include Resume and Relaunch buttons on workflow error'() {
+    def 'should include only View button on workflow error until resume URL exists'() {
         given:
         def platformConfig = new SlackConfig([
             webhook: 'https://hooks.slack.com/test',
@@ -675,7 +676,7 @@ class SlackMessageBuilderTest extends Specification {
 
         then:
         def actionsBlock = json.blocks.find { it.type == 'actions' }
-        actionsBlock.elements*.text.text == ['🔗 View in Seqera Platform', '▶️ Resume', '🔄 Relaunch']
+        actionsBlock.elements*.text.text == ['🔗 View in Seqera Platform']
     }
 
     def 'should include Seqera Platform buttons in progress update when watchUrl is available'() {
@@ -687,7 +688,7 @@ class SlackMessageBuilderTest extends Specification {
         def mockMetadata = Mock(WorkflowMetadata)
         mockMetadata.scriptName >> 'test-workflow.nf'
         def towerSession = Mock(Session)
-        towerSession.config >> [:]
+        towerSession.config >> [tower: [endpoint: 'https://api.cloud.seqera.io']]
         towerSession.workflowMetadata >> mockMetadata
         towerSession.runName >> 'crazy_einstein'
         towerSession.uniqueId >> UUID.fromString('00000000-0000-0000-0000-000000000000')
@@ -702,9 +703,10 @@ class SlackMessageBuilderTest extends Specification {
         def actionsBlock = json.blocks.find { it.type == 'actions' }
         actionsBlock != null
         actionsBlock.elements*.text.text == ['🔗 View in Seqera Platform', '⏹ Cancel']
+        actionsBlock.elements[1].url == 'https://api.cloud.seqera.io/workflow/abc123/cancel'
     }
 
-    def 'should include View and Relaunch buttons on workflow complete message'() {
+    def 'should include only View button on workflow complete message until relaunch URL exists'() {
         given:
         def platformConfig = new SlackConfig([
             webhook: 'https://hooks.slack.com/test',
@@ -728,7 +730,7 @@ class SlackMessageBuilderTest extends Specification {
 
         then:
         def actionsBlock = json.blocks.find { it.type == 'actions' }
-        actionsBlock.elements*.text.text == ['🔗 View in Seqera Platform', '🔄 Relaunch']
+        actionsBlock.elements*.text.text == ['🔗 View in Seqera Platform']
     }
 
     def 'should not include Seqera Platform button when no TowerClient present'() {

--- a/src/test/groovy/nextflow/slack/SlackMessageBuilderTest.groovy
+++ b/src/test/groovy/nextflow/slack/SlackMessageBuilderTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Seqera Labs
+ * Copyright 2025-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/nextflow/slack/SlackMessageBuilderTest.groovy
+++ b/src/test/groovy/nextflow/slack/SlackMessageBuilderTest.groovy
@@ -678,6 +678,59 @@ class SlackMessageBuilderTest extends Specification {
         actionsBlock.elements*.text.text == ['🔗 View in Seqera Platform', '▶️ Resume', '🔄 Relaunch']
     }
 
+    def 'should include Seqera Platform buttons in progress update when watchUrl is available'() {
+        given:
+        def platformConfig = new SlackConfig([
+            webhook: 'https://hooks.slack.com/test',
+            seqeraPlatform: [enabled: true]
+        ])
+        def mockMetadata = Mock(WorkflowMetadata)
+        mockMetadata.scriptName >> 'test-workflow.nf'
+        def towerSession = Mock(Session)
+        towerSession.config >> [:]
+        towerSession.workflowMetadata >> mockMetadata
+        towerSession.runName >> 'crazy_einstein'
+        towerSession.uniqueId >> UUID.fromString('00000000-0000-0000-0000-000000000000')
+        def builder = Spy(new SlackMessageBuilder(platformConfig, towerSession))
+        builder.getTowerClientWatchUrl() >> 'https://cloud.seqera.io/orgs/myorg/workspaces/myws/watch/abc123'
+
+        when:
+        def message = builder.buildProgressUpdateMessage(10, 5, 2, 0, 60000L, null)
+        def json = new JsonSlurper().parseText(message)
+
+        then:
+        def actionsBlock = json.blocks.find { it.type == 'actions' }
+        actionsBlock != null
+        actionsBlock.elements*.text.text == ['🔗 View in Seqera Platform', '⏹ Cancel']
+    }
+
+    def 'should include View and Relaunch buttons on workflow complete message'() {
+        given:
+        def platformConfig = new SlackConfig([
+            webhook: 'https://hooks.slack.com/test',
+            seqeraPlatform: [enabled: true]
+        ])
+        def mockMetadata = Mock(WorkflowMetadata)
+        mockMetadata.scriptName >> 'test-workflow.nf'
+        mockMetadata.duration >> nextflow.util.Duration.of('1h')
+        mockMetadata.stats >> null
+        def towerSession = Mock(Session)
+        towerSession.config >> [:]
+        towerSession.workflowMetadata >> mockMetadata
+        towerSession.runName >> 'crazy_einstein'
+        towerSession.uniqueId >> UUID.fromString('00000000-0000-0000-0000-000000000000')
+        def builder = Spy(new SlackMessageBuilder(platformConfig, towerSession))
+        builder.getTowerClientWatchUrl() >> 'https://cloud.seqera.io/orgs/myorg/workspaces/myws/watch/abc123'
+
+        when:
+        def message = builder.buildWorkflowCompleteMessage()
+        def json = new JsonSlurper().parseText(message)
+
+        then:
+        def actionsBlock = json.blocks.find { it.type == 'actions' }
+        actionsBlock.elements*.text.text == ['🔗 View in Seqera Platform', '🔄 Relaunch']
+    }
+
     def 'should not include Seqera Platform button when no TowerClient present'() {
         when:
         def message = messageBuilder.buildWorkflowStartMessage()

--- a/src/test/groovy/nextflow/slack/SlackObserverTest.groovy
+++ b/src/test/groovy/nextflow/slack/SlackObserverTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Seqera Labs
+ * Copyright 2025-2026, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

Partially addresses #65

Adds contextual Seqera Platform action buttons to Slack notifications when running with nf-tower / Seqera Platform.

### Button behaviour

| Phase | Buttons |
|-------|---------|
| Running (start/progress) | **View** (Platform run page) + **Cancel** (Platform API) |
| Failed | **View** only |
| Completed | **View** only |

- **View** — opens the Platform `watchUrl` from TowerClient
- **Cancel** — links to `{tower.endpoint}/workflow/{runId}/cancel` ([Platform API](https://docs.seqera.io/platform-api/cancel-workflow)); API base comes from `tower.endpoint` in Nextflow config
- **Resume / Relaunch** — not shown yet; they require `POST /workflow/launch` with a prepared body rather than a per-run URL

### Configuration

```groovy
slack {
    bot {
        token = System.getenv('SLACK_BOT_TOKEN')
        channel = System.getenv('SLACK_CHANNEL_ID')
    }
    seqeraPlatform {
        enabled = true
        actionButtons {
            cancel = true    // View + Cancel while running
            resume = true    // reserved
            relaunch = true  // reserved
        }
    }
}
```

Requires `tower.enabled = true` (or `-with-tower`) so nf-tower registers the run and provides a watch URL.

### Removed

- **Interactive mode** (`actionButtons.mode = 'interactive'`) — dropped in favour of direct URL buttons

## Test plan

- [x] `./gradlew test` — all tests pass
- [x] Cancel API URL generation verified
- [x] Start/progress messages include View + Cancel
- [x] Complete/error messages include View only
- [x] Config parsing for `actionButtons` verified